### PR TITLE
Rework the Tweaker system

### DIFF
--- a/ModManager/Views/Components/ModTweaker.xaml
+++ b/ModManager/Views/Components/ModTweaker.xaml
@@ -58,7 +58,7 @@
                                     </TextBlock>
                                 </Expander.Header>
 
-                                <ItemsControl ItemsSource="{Binding EditableValues}">
+                                <ItemsControl ItemsSource="{Binding Exposes}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
                                             <Border HorizontalAlignment="Left"
@@ -70,7 +70,7 @@
                                                         <ColumnDefinition />
                                                         <ColumnDefinition Width="2*" />
                                                     </Grid.ColumnDefinitions>
-                                                    <TextBlock Text="{Binding Key}"
+                                                    <TextBlock Text="{Binding ExposeID}"
                                                                Style="{StaticResource IMYA_TEXT}"
                                                                VerticalAlignment="Center"
                                                                Margin="10,0,0,0"
@@ -78,7 +78,7 @@
                                                     <TextBox Grid.Column="1"
                                                              Style="{StaticResource IMYA_TEXTBOX}"
                                                              Background="{DynamicResource InteractiveComponentColorBrush}"
-                                                             Text="{Binding Value}"
+                                                             Text="{Binding Value, Mode=TwoWay}"
                                                              TextAlignment="Justify"
                                                              MinWidth="40"
                                                              Margin="0,4,4,4" />

--- a/ModManager/Views/Components/ModTweaker.xaml.cs
+++ b/ModManager/Views/Components/ModTweaker.xaml.cs
@@ -88,14 +88,6 @@ namespace Imya.UI.Components
                         
                         if (mod is not null)
                             tweaks.Load(mod);
-
-                        if (currentTweaks.TweakerFiles is not null)
-                        {
-                            foreach (TweakerFile file in currentTweaks.TweakerFiles)
-                            {
-                                file.TweakStorage?.Save(file.BasePath);
-                            }
-                        }
                     }
 
                     Dispatcher.BeginInvoke(() =>
@@ -112,10 +104,6 @@ namespace Imya.UI.Components
             ThreadPool.QueueUserWorkItem(o =>
                 {
                     tweaks.Save();
-                    foreach (TweakerFile file in tweaks.TweakerFiles)
-                    {
-                        file.TweakStorage?.Save(file.BasePath);
-                    }
                 });
 
             

--- a/ModManager_Classes/Models/ModTweaker/ExposedModValue.cs
+++ b/ModManager_Classes/Models/ModTweaker/ExposedModValue.cs
@@ -1,26 +1,39 @@
-﻿using System.Text.RegularExpressions;
+﻿using Imya.Models.NotifyPropertyChanged;
+using Imya.Utils;
+using System.Text.RegularExpressions;
 using System.Xml;
 
 namespace Imya.Models.ModTweaker
 {
     public class ExposedModValue
     {
-        public String Key { get; }
-        private XmlNode ValueNode { get; }
-        public String Value { get => ValueNode.InnerText; set => SetValue(value); }
-
-        public ExposedModValue(XmlNode value, String key)
+        public String Path;
+        public String ModOpID;
+        public String ExposeID { get; private set; }
+        public String Value
         {
-            ValueNode = value; 
-            Key = key;
-
-            SetValue(ValueNode.InnerText);
+            get => _value;
+            set
+            {
+                _value = value;
+                Parent.TweakStorage!.SetTweakValue(Parent.FilePath, ExposeID, Value);
+            }
         }
 
-        public void SetValue(String content)
+        public TweakerFile Parent { get; set; }
+
+        private String _value;
+
+        public static ExposedModValue? FromXmlNode(XmlNode Expose)
         {
-            //ValueNode.Value = Regex.Replace(content, @"\s+", "");
-            ValueNode.Value = content.TrimStart().TrimEnd();
+            if (Expose.TryGetAttribute(TweakerConstants.EXPOSE_PATH, out String? Path)
+                && Expose.TryGetAttribute(TweakerConstants.MODOP_ID, out String? ModOpID)
+                && Expose.TryGetAttribute(TweakerConstants.EXPOSE_ATTR, out String? ExposeID))
+            {
+                return new ExposedModValue() { Path = Path!, ModOpID = ModOpID!, ExposeID = ExposeID! };
+            }
+            return null;
         }
     }
+
 }

--- a/ModManager_Classes/Models/ModTweaker/ExposedModValue.cs
+++ b/ModManager_Classes/Models/ModTweaker/ExposedModValue.cs
@@ -16,7 +16,7 @@ namespace Imya.Models.ModTweaker
             set
             {
                 _value = value;
-                Parent.TweakStorage!.SetTweakValue(Parent.FilePath, ExposeID, Value);
+                Parent.TweakStorage.SetTweakValue(Parent.FilePath, ExposeID, Value);
             }
         }
 
@@ -24,13 +24,13 @@ namespace Imya.Models.ModTweaker
 
         private String _value;
 
-        public static ExposedModValue? FromXmlNode(XmlNode Expose)
+        public static ExposedModValue? FromXmlNode(XmlNode Expose, TweakerFile parent)
         {
             if (Expose.TryGetAttribute(TweakerConstants.EXPOSE_PATH, out String? Path)
                 && Expose.TryGetAttribute(TweakerConstants.MODOP_ID, out String? ModOpID)
                 && Expose.TryGetAttribute(TweakerConstants.EXPOSE_ATTR, out String? ExposeID))
             {
-                return new ExposedModValue() { Path = Path!, ModOpID = ModOpID!, ExposeID = ExposeID! };
+                return new ExposedModValue() { Path = Path!, ModOpID = ModOpID!, ExposeID = ExposeID!, Parent = parent};
             }
             return null;
         }

--- a/ModManager_Classes/Models/ModTweaker/ITweakStorage.cs
+++ b/ModManager_Classes/Models/ModTweaker/ITweakStorage.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imya.Models.ModTweaker
+{
+    public interface ITweakStorage
+    {
+        public void SetTweakValue(String Filename, String ExposeID, String NewValue);
+        public bool TryGetTweakValue(String Filename, String ExposeID, out String? Value);
+
+        public void Save(String FilenameBase);
+    }
+}

--- a/ModManager_Classes/Models/ModTweaker/ModOp.cs
+++ b/ModManager_Classes/Models/ModTweaker/ModOp.cs
@@ -1,0 +1,45 @@
+﻿using Imya.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Imya.Models.ModTweaker
+{
+    public class ModOp
+    {
+        public String? ID;
+        public XmlNodeList Code;
+
+        //Mod Op related things
+        public String Type;
+        public String? GUID;
+        public String? Path;
+
+        public bool IsValid => GUID is String || Path is String;
+        public bool HasID => ID is String;
+
+        public static ModOp? FromXmlNode(XmlNode ModOp)
+        {
+            if (ModOp.HasChildNodes
+                && ModOp.TryGetAttribute(TweakerConstants.TYPE, out String? ModOpType))
+            {
+                ModOp.TryGetAttribute(TweakerConstants.GUID, out String? Guid);
+                ModOp.TryGetAttribute(TweakerConstants.PATH, out String? Path);
+                ModOp.TryGetAttribute(TweakerConstants.MODOP_ID, out String? ID);
+                return new ModOp
+                {
+                    ID = ID!,
+                    Code = ModOp.ChildNodes,
+                    Type = ModOpType!,
+                    GUID = Guid,
+                    Path = Path
+                };
+            }
+            return null;
+        }
+    }
+
+}

--- a/ModManager_Classes/Models/ModTweaker/ModTweaks.cs
+++ b/ModManager_Classes/Models/ModTweaker/ModTweaks.cs
@@ -21,15 +21,20 @@ namespace Imya.Models.ModTweaker
 
         private Mod? _mod = null;
 
+        private String? ModBaseName => _mod?.FolderName;
+
         public void Load(Mod mod)
         {
-            _mod = mod;
+            if (mod is null) return; 
 
-            var files = mod.GetFilesWithExtension("xml").Select(x => Path.GetRelativePath(mod.FullModPath, x)).ToArray();
+            _mod = mod;
+            var files = mod.GetFilesWithExtension("xml").Where(x => !x.EndsWith("imyatweak.xml")).Select(x => Path.GetRelativePath(mod.FullModPath, x)).ToArray();
             var list = new ObservableCollection<TweakerFile>();
+
+            var tweakStorage = TweakCollection.LoadOrCreate(ModBaseName!);
             foreach (string filename in files)
             {
-                if (TweakerFile.TryInit(mod.FullModPath, filename, out var file))
+                if (TweakerFile.TryInit(mod.FullModPath, filename, tweakStorage, out var file))
                 {
                     list.Add(file);
                 }

--- a/ModManager_Classes/Models/ModTweaker/ModTweaks.cs
+++ b/ModManager_Classes/Models/ModTweaker/ModTweaks.cs
@@ -23,6 +23,7 @@ namespace Imya.Models.ModTweaker
 
         private String? ModBaseName => _mod?.FolderName;
 
+        public ITweakStorage TweakStorage;
         public void Load(Mod mod)
         {
             if (mod is null) return; 
@@ -31,10 +32,10 @@ namespace Imya.Models.ModTweaker
             var files = mod.GetFilesWithExtension("xml").Where(x => !x.EndsWith("imyatweak.xml")).Select(x => Path.GetRelativePath(mod.FullModPath, x)).ToArray();
             var list = new ObservableCollection<TweakerFile>();
 
-            var tweakStorage = TweakCollection.LoadOrCreate(ModBaseName!);
+            TweakStorage = TweakCollection.LoadOrCreate(ModBaseName!);
             foreach (string filename in files)
             {
-                if (TweakerFile.TryInit(mod.FullModPath, filename, tweakStorage, out var file))
+                if (TweakerFile.TryInit(mod.FullModPath, filename, TweakStorage, out var file))
                 {
                     list.Add(file);
                 }
@@ -44,13 +45,15 @@ namespace Imya.Models.ModTweaker
 
         public void Save()
         {
-            if (TweakerFiles != null && _mod != null)
+            if (TweakerFiles != null && TweakerFiles.Count > 0 && _mod != null)
             {
                 foreach (var f in TweakerFiles)
                 {
                     f.Save(_mod.FullModPath);
                 }
+                TweakStorage.Save(ModBaseName);
             }
+
         }
     }
 }

--- a/ModManager_Classes/Models/ModTweaker/TweakCollection.cs
+++ b/ModManager_Classes/Models/ModTweaker/TweakCollection.cs
@@ -1,0 +1,97 @@
+﻿using Imya.Utils;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imya.Models.ModTweaker
+{
+
+    public class TweakCollection : ITweakStorage
+    {
+        public Dictionary<String, Tweak> Tweaks { get; set; } = new();
+
+        public TweakCollection()
+        {
+
+        }
+
+        public void SetTweakValue(string Filename, string ExposeID, string NewValue)
+        {
+            AddOrGetTweak(Filename).SetTweakValue(ExposeID, NewValue);
+        }
+
+        public bool TryGetTweakValue(string Filename, string ExposeID, out string? Value)
+        {
+            Value = GetTweak(Filename)?.GetTweakValue(ExposeID);
+            return Value is not null;
+        }
+
+        public Tweak? GetTweak(String Filename)
+        {
+            return Tweaks.SafeGet(Filename);
+        }
+
+        public Tweak AddOrGetTweak(String Filename)
+        {
+            return Tweaks.SafeAddOrGet(Filename);
+        }
+
+        public void Save(String FilenameBase)
+        {
+            //filter name to be on the safe side.
+            FilenameBase = Path.GetFileName(FilenameBase);
+
+            String s = JsonConvert.SerializeObject(Tweaks, Formatting.Indented);
+            using (StreamWriter writer = new StreamWriter(File.Create($"{FilenameBase}.json")))
+            {
+                writer.Write(s);
+            }
+        }
+
+        public static TweakCollection? LoadFromFile(String FilenameBase)
+        {
+            try
+            {
+                return LoadFromJson(File.ReadAllText($"{FilenameBase}.json"));
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Loads a Tweak Collection From the file with the specified ID. If there is no stored collection, it creates a new one.
+        /// </summary>
+        /// <param name="FilenameBase"></param>
+        /// <returns>The tweak collection</returns>
+        public static TweakCollection LoadOrCreate(String FilenameBase)
+        {
+            var coll = LoadFromFile(FilenameBase);
+            if (coll is not null) return coll;
+
+            return new TweakCollection();
+        }
+
+        public static TweakCollection? LoadFromJson(String JsonString)
+        {
+            try
+            {
+                var coll = new TweakCollection();
+                var tweaks = JsonConvert.DeserializeObject<Dictionary<String, Tweak>>(JsonString);
+                if (tweaks is null) return null;
+                coll.Tweaks = tweaks;
+
+                return coll;
+            }
+            catch (JsonSerializationException e)
+            {
+                Console.WriteLine("Could not load Tweak Collection");
+                return null;
+            }
+        }
+    }
+}

--- a/ModManager_Classes/Models/ModTweaker/TweakStore.cs
+++ b/ModManager_Classes/Models/ModTweaker/TweakStore.cs
@@ -1,0 +1,55 @@
+﻿using Imya.Utils;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imya.Models.ModTweaker
+{
+    /// <summary>
+    /// A quick and dirty way to store the tweaks we did. 
+    /// </summary>
+    /// 
+    public class TweakStorage
+    {
+        public static TweakStorage Global { get; } = new TweakStorage();
+
+        public TweakStorage() { }
+
+        private Dictionary<String, TweakCollection> Tweaks = new(); 
+
+        /// <summary>
+        /// Gets the Tweak Storage for an ID. If it does not exist, it creates a new one.
+        /// </summary>
+        /// <param name="ID"></param>
+        /// <returns></returns>
+        public ITweakStorage Get(String ID)
+        {
+            return Tweaks.SafeAddOrGet(ID);
+        }
+
+        public void SaveAll()
+        {
+            foreach (var (key, value) in Tweaks)
+            {
+                value.Save(key);
+            }
+        }
+    }
+
+    public class Tweak
+    {
+        /// <summary>
+        /// Expose ID <-> Stored Value
+        /// </summary>
+        public Dictionary<String, String> Values { get; set; } = new();
+
+        public String? GetTweakValue(String ExposeID)
+        {
+            return Values.SafeGet(ExposeID);
+        }
+        public void SetTweakValue(String ExposeID, String Value) => Values[ExposeID] = Value;
+    }
+}

--- a/ModManager_Classes/Models/ModTweaker/TweakerFile.cs
+++ b/ModManager_Classes/Models/ModTweaker/TweakerFile.cs
@@ -30,7 +30,7 @@ namespace Imya.Models.ModTweaker
     {
         public String BasePath { get; private set; }
         public String FilePath { get; private set; }
-        public String BaseFilePath => FilePath.Substring(0, FilePath.Length - Path.GetFileName(SourceFilename).Length);
+        public String BaseFilePath => Path.GetDirectoryName(FilePath);
         public String SourceFilename { get; private set; }
         public String EditFilename => Path.GetFileNameWithoutExtension(SourceFilename) + ".imyatweak.xml";
 
@@ -61,7 +61,7 @@ namespace Imya.Models.ModTweaker
         private XmlDocument TargetDocument { get; set; } = new XmlDocument();
         private XmlNode TargetRoot { get; init; }
 
-        public ITweakStorage? TweakStorage;
+        public ITweakStorage TweakStorage;
 
         private TweakerFile(String _filepath, String _basepath)
         {

--- a/ModManager_Classes/Models/ModTweaker/TweakerFile.cs
+++ b/ModManager_Classes/Models/ModTweaker/TweakerFile.cs
@@ -1,4 +1,5 @@
 ﻿using Imya.Models.NotifyPropertyChanged;
+using Imya.Utils;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -9,60 +10,292 @@ using System.Xml;
 
 namespace Imya.Models.ModTweaker
 {
+    public struct TweakerConstants
+    {
+        public static readonly String EXPOSE_STRING = "ImyaExpose";
+        public static readonly String EXPOSE_ATTR = "ExposeID";
+        public static readonly String EXPOSE_PATH = "Path";
+        public static readonly String MODOP_ID = "ModOpID";
+
+        public static readonly String PATH = "Path";
+        public static readonly String TYPE = "Type";
+        public static readonly String GUID = "GUID";
+    }
+    
+    /// <summary>
+    /// This is basically the same as ExposedModValue
+    /// </summary>
+    
     public class TweakerFile : PropertyChangedNotifier
     {
-        public string FilePath { get; private set; }
-        public ObservableCollection<ExposedModValue> EditableValues 
+        public String BasePath { get; private set; }
+        public String FilePath { get; private set; }
+        public String BaseFilePath => FilePath.Substring(0, FilePath.Length - Path.GetFileName(SourceFilename).Length);
+        public String SourceFilename { get; private set; }
+        public String EditFilename => Path.GetFileNameWithoutExtension(SourceFilename) + ".imyatweak.xml";
+
+        public ObservableCollection<ExposedModValue> Exposes
         {
-            get => _editableValues;
+            get => _exposes;
             private set
             {
-                _editableValues = value;
-                OnPropertyChanged(nameof(EditableValues));
+                _exposes = value;
+                OnPropertyChanged(nameof(Exposes));
             }
         }
-        private ObservableCollection<ExposedModValue> _editableValues;
-        public XmlDocument OwnerDocument { get; private set; } = new XmlDocument();
+        private ObservableCollection<ExposedModValue> _exposes;
 
-        private FileSystemWatcher watcher;
-
-        private TweakerFile()
+        //ModOps in here need to have an ID. This is considered by the XMLPatchParser.
+        public ObservableCollection<ModOp> ModOps
         {
+            get => _mod_ops;
+            set
+            {
+                _mod_ops = value;
+                OnPropertyChanged(nameof(ModOps));
+            }
+        }
+        private ObservableCollection<ModOp> _mod_ops;
 
+        private XmlDocument OriginalDocument { get; set; } = new XmlDocument();
+        private XmlDocument TargetDocument { get; set; } = new XmlDocument();
+        private XmlNode TargetRoot { get; init; }
+
+        public ITweakStorage? TweakStorage;
+
+        private TweakerFile(String _filepath, String _basepath)
+        {
+            FilePath = _filepath;
+            BasePath = _basepath;
+
+            SourceFilename = Path.GetFileName(_filepath);
+
+            var node = TargetDocument.CreateElement("ModOps");
+            TargetDocument.AppendChild(node);
+            TargetRoot = node;
+        }
+
+        public ExposedModValue? GetExpose(String ExposeID)
+        {
+            return Exposes.First(x => x.ExposeID.Equals(ExposeID));
+        }
+
+        public bool ExposeExists(String ExposeID)
+        {
+            return Exposes.Any(x => x.ExposeID.Equals(ExposeID));
+        }
+
+        #region ModopManipulation
+
+        /// <summary>
+        /// Get's the default value for an expose from the original document
+        /// </summary>
+        /// <param name="expose"></param>
+        /// <returns>The default value as String</returns>
+        public String GetDefaultNodeValue(ExposedModValue expose)
+        {
+            var op = ModOps.Where(x => x.HasID && x.ID!.Equals(expose.ModOpID)).First();
+
+            foreach (XmlNode x in op.Code)
+            {
+                var node = OriginalDocument.SelectSingleNode(expose.Path);
+                if (node is not null) return node.InnerText;
+            }
+            return String.Empty;
+        }
+
+        /// <summary>
+        /// Generates the ModOp as XML node in the target document
+        /// </summary>
+        /// <param name="modop"></param>
+        /// <returns>The xml node that was generated</returns>
+        public XmlNode? Generate(ModOp modop)
+        {
+            var elem = TargetDocument.CreateElement("ModOp");
+
+            if (modop.Path is not null)
+            {
+                var PathAttr = TargetDocument.CreateAttribute(TweakerConstants.PATH);
+                PathAttr.Value = modop.Path;
+                elem.Attributes.Append(PathAttr);
+            }
+
+            if (modop.GUID is not null)
+            {
+                var GuidAttr = TargetDocument.CreateAttribute(TweakerConstants.GUID);
+                GuidAttr.Value = modop.GUID;
+                elem.Attributes.Append(GuidAttr);
+            }
+
+            var TypeAttr = TargetDocument.CreateAttribute(TweakerConstants.TYPE);
+            TypeAttr.Value = modop.Type;
+
+            elem.Attributes.Append(TypeAttr);
+
+            foreach (XmlNode n in modop.Code)
+            {
+                //check whether we need deep cloning later
+                var import = TargetDocument.ImportNode(n, true);
+                elem.AppendChild(import);
+            }
+
+            TargetRoot.AppendChild(elem);
+
+            return elem;
+        }
+
+        /// <summary>
+        /// Executes A collection of exposes on <paramref name="node"/>. 
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="exposes"></param>
+        /// <param name="NewValue"></param>
+        /// <returns>Whether any exposes were executed on the node.</returns>
+        public bool ExecuteExposes(XmlNode node, IEnumerable<ExposedModValue> exposes, String NewValue)
+        {
+            bool AnyExecutes = false;
+            foreach (ExposedModValue x in exposes)
+            {
+                bool Executed = ExecuteExpose(node, x);
+                //if no executes were done yet, consider the current value, else stay true.
+                AnyExecutes = AnyExecutes ? true : Executed;
+            }
+            return AnyExecutes;
+        }
+
+        /// <summary>
+        /// Ensures that an XML node has a skip attribute
+        /// </summary>
+        /// <param name="n"></param>
+        public void EnsureSkipFlag(XmlNode? n)
+        {
+            if (n is null || n.OwnerDocument is null || n.TryGetAttribute("Skip", out var _)) return;
+
+            var attrib = n.OwnerDocument!.CreateAttribute("Skip");
+            attrib.Value = "1";
+            n.Attributes!.Append(attrib);
+        }
+
+        public void EnsureInclude()
+        {
+            String Filepath = $"../{EditFilename}";
+            if (OriginalDocument.SelectSingleNode($"/ModOps/Include[@File = '{Filepath}']") is not null) return;
+
+            var n = OriginalDocument.CreateElement("Include");
+
+            var attrib = OriginalDocument.CreateAttribute("File");
+            attrib.Value = Filepath;
+            n.Attributes!.Append(attrib);
+
+            OriginalDocument.FirstChild?.AppendChild(n);
+        }
+
+        /// <summary>
+        /// Executes an Expose on <paramref name="node"/>.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="expose"></param>
+        /// <param name="NewValue"></param>
+        /// <returns>Whether the expose needed to be executed.</returns>
+        private bool ExecuteExpose(XmlNode node, ExposedModValue expose)
+        {
+            var nodesToEdit = node.SelectNodes(expose.Path);
+            if (nodesToEdit is null || nodesToEdit.Count == 0) return false;
+
+            foreach (XmlNode n in nodesToEdit)
+            {
+                n.InnerText = expose.Value;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Executes an Expose on the entire target document.
+        /// </summary>
+        /// <param name="expose"></param>
+        /// <returns>Whether the expose needed to be executed.</returns>
+        internal bool ExecuteExpose(ExposedModValue expose)
+        {
+            var ops = ModOps.Where(x => x.HasID && x.ID!.Equals(expose.ModOpID));
+
+            List<bool> SuccessTracker = new();
+            foreach (ModOp n in ops)
+            {
+                foreach (XmlNode x in n.Code)
+                {
+                    bool b = ExecuteExpose(x, expose);
+                    SuccessTracker.Add(b);
+                }
+            }
+            return SuccessTracker.Any(x => x == true);
+        }
+
+        #endregion
+
+        #region LoadSave
+
+        public void Export()
+        {
+            foreach (ExposedModValue e in Exposes)
+            {
+                ExecuteExpose(e);
+            }
+            //ensure that the source document includes what we want.
+            EnsureInclude();
+            foreach (ModOp op in ModOps)
+            {
+                //ensure a skip in the source document.
+                OriginalDocument.TryGetModOpNode(op.ID!, out var modop);
+                EnsureSkipFlag(modop);
+
+                //generate the mod op in the target document
+                Generate(op);
+            }
         }
 
         public void Save(string basePath)
         {
+            Export();
+
             try
             {
-                OwnerDocument.Save(Path.Combine(basePath, FilePath));
+                OriginalDocument.Save(Path.Combine(basePath, BaseFilePath, SourceFilename));
+                TargetDocument.Save(Path.Combine(basePath, BaseFilePath, EditFilename));
             }
             catch (IOException e)
             {
                 Console.WriteLine($"Failed to save Document {FilePath}. Cause: {e.Message}");
+                return;
             }
         }
 
-        public static bool TryInit(string basePath, string filePath, out TweakerFile tweakerFile)
+        public static bool TryInit(string basePath, string filePath, ITweakStorage tweakStorage, out TweakerFile tweakerFile)
         {
-            tweakerFile = new();
-            tweakerFile.FilePath = filePath;
+            tweakerFile = new(filePath, basePath);
 
             if (tweakerFile.TryLoadOwnerDocument(basePath, out var doc))
             {
-                tweakerFile.OwnerDocument = doc;
+                tweakerFile.OriginalDocument = doc;
+                tweakerFile.BasePath = Path.GetFileName(basePath);
+
+                tweakerFile.TweakStorage = tweakStorage;
 
                 var parser = new XmlPatchParser(doc);
-                var editables = parser.FetchExposedValues();
+                var editables = parser.FetchExposes(tweakerFile);
+
+                tweakerFile.ModOps = new ObservableCollection<ModOp>(parser.FetchModOps(tweakerFile.TargetDocument));
+
                 if (!editables.Any())
                 {
                     return false;
                 }
+                tweakerFile.Exposes = new ObservableCollection<ExposedModValue>(editables);
 
-                tweakerFile.EditableValues = new ObservableCollection<ExposedModValue>(editables);
+
                 return true;
             }
-            else {
+            else
+            {
                 Console.WriteLine($"Could not load Document: {tweakerFile.FilePath}");
             }
             return false;
@@ -77,9 +310,12 @@ namespace Imya.Models.ModTweaker
             }
             catch (XmlException e)
             {
+                Console.WriteLine(e.Message);
                 return false;
             }
             return true;
         }
+
+        #endregion
     }
 }

--- a/ModManager_Classes/Models/ModTweaker/XmlPatchParser.cs
+++ b/ModManager_Classes/Models/ModTweaker/XmlPatchParser.cs
@@ -44,24 +44,31 @@ namespace Imya.Models.ModTweaker
             foreach (XmlNode ExposeInstruction in ExposedValues)
             {
                 //per expose instruction
-                ExposedModValue? expose = ExposedModValue.FromXmlNode(ExposeInstruction, parent);
-
-                if (expose is null) return;
-
-                if (parent.TweakStorage.TryGetTweakValue(parent.FilePath, expose.ExposeID, out var value))
-                {
-                    expose.Value = value!;
-                }
-                else
-                {
-                    expose.Value = parent.GetDefaultNodeValue(expose);
-                }
-
+                ExposedModValue? expose = FetchExpose(ExposeInstruction, parent);
                 if (expose is not null)
                 {
                     yield return expose;
                 }
             }
+        }
+
+        private ExposedModValue? FetchExpose(XmlNode ExposeInstruction, TweakerFile parent)
+        {
+            //per expose instruction
+            ExposedModValue? expose = ExposedModValue.FromXmlNode(ExposeInstruction, parent);
+
+            if (expose is null) return null;
+
+            if (parent.TweakStorage.TryGetTweakValue(parent.FilePath, expose.ExposeID, out var value))
+            {
+                expose.Value = value!;
+            }
+            else
+            {
+                expose.Value = parent.GetDefaultNodeValue(expose);
+            }
+
+            return expose;
         }
 
         internal IEnumerable<ModOp> FetchModOps(XmlDocument ImportDocument)

--- a/ModManager_Classes/Models/ModTweaker/XmlPatchParser.cs
+++ b/ModManager_Classes/Models/ModTweaker/XmlPatchParser.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Imya.Utils;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,10 +10,6 @@ namespace Imya.Models.ModTweaker
 {
     internal class XmlPatchParser
     {
-        private static readonly String EXPOSE_STRING = "ImyaExpose";
-        private static readonly String EXPOSE_ATTR = "ExposeID";
-        private static readonly String EXPOSE_PATH = "Path";
-
         private XmlDocument Document;
 
         internal XmlPatchParser(XmlDocument doc)
@@ -20,38 +17,80 @@ namespace Imya.Models.ModTweaker
             Document = doc;
         }
 
-        internal IEnumerable<ExposedModValue> FetchExposedValues()
+        /*
+        internal IEnumerable<ExposedModValue> FetchExposedValues(TweakerFile parent)
         {
-            var ExposedValues = Document.SelectNodes($"//{EXPOSE_STRING}");
+            var ExposedValues = Document.SelectNodes($"//{TweakerConstants.EXPOSE_STRING}");
+            if (ExposedValues is null) yield break;
 
             foreach (XmlNode ExposeInstruction in ExposedValues)
             {
                 //per expose instruction
-                String? Path = ExposeInstruction.Attributes?[EXPOSE_PATH]?.Value;
-                String? ExposeID = ExposeInstruction.Attributes?[EXPOSE_ATTR]?.Value;
+                Expose? expose = Expose.FromXmlNode(ExposeInstruction);
 
-                if (TryFetchExposedValue(Path, ExposeID, out var ExposedModValue))
+                if (expose is not null && TryFetchExposedValue(expose, parent, out var ExposedModValue))
                 {
                     yield return ExposedModValue;
                 }
             }
         }
+        */
 
-        internal bool TryFetchExposedValue(String Path, String ExposeID, out ExposedModValue exposedModValue)
+        internal IEnumerable<ExposedModValue> FetchExposes(TweakerFile parent)
         {
-            if (Path is not null && ExposeID is not null)
+            var ExposedValues = Document.SelectNodes($"//{TweakerConstants.EXPOSE_STRING}");
+            if (ExposedValues is null) yield break;
+
+            foreach (XmlNode ExposeInstruction in ExposedValues)
             {
-                var node = Document.SelectSingleNode(Path);
+                //per expose instruction
+                ExposedModValue? expose = ExposedModValue.FromXmlNode(ExposeInstruction);
+
+                expose.Parent = parent;
+
+                if (parent.TweakStorage.TryGetTweakValue(parent.FilePath, expose.ExposeID, out var value))
+                {
+                    expose.Value = value!;
+                }
+                else
+                {
+                    expose.Value = parent.GetDefaultNodeValue(expose);
+                }
+
+                if (expose is not null)
+                {
+                    yield return expose;
+                }
+            }
+        }
+
+        internal IEnumerable<ModOp> FetchModOps(XmlDocument ImportDocument)
+        { 
+            var ModOps = Document.SelectNodes("/ModOps/ModOp");
+
+            foreach (XmlNode _ModOp in ModOps)
+            {
+                var Imported = ImportDocument.ImportNode(_ModOp, true);
+                ModOp? op = ModOp.FromXmlNode(Imported);
+                if (op is not null && op.HasID) yield return op;
+            }
+        }
+        /*
+        internal bool TryFetchExposedValue(Expose Expose, TweakerFile parent, out ExposedModValue exposedModValue)
+        {
+            if (Expose.Path is not null && Expose.ExposeID is not null && Document.TryGetModOpNode("Heater", out var modop))
+            {
+                var node = modop.SelectSingleNode(Expose.Path);
                 var TextNode = node?.SelectSingleNode("./text()");
 
                 if (TextNode is not null)
                 {
-                    exposedModValue = new ExposedModValue(TextNode, ExposeID);
+                    exposedModValue = new ExposedModValue(TextNode, Expose.ExposeID, parent);
                     return true;
                 }
             }
             exposedModValue = null;
             return false;
-        }
+        }*/
     }
 }

--- a/ModManager_Classes/Models/ModTweaker/XmlPatchParser.cs
+++ b/ModManager_Classes/Models/ModTweaker/XmlPatchParser.cs
@@ -44,9 +44,9 @@ namespace Imya.Models.ModTweaker
             foreach (XmlNode ExposeInstruction in ExposedValues)
             {
                 //per expose instruction
-                ExposedModValue? expose = ExposedModValue.FromXmlNode(ExposeInstruction);
+                ExposedModValue? expose = ExposedModValue.FromXmlNode(ExposeInstruction, parent);
 
-                expose.Parent = parent;
+                if (expose is null) return;
 
                 if (parent.TweakStorage.TryGetTweakValue(parent.FilePath, expose.ExposeID, out var value))
                 {

--- a/ModManager_Classes/Utils/FrameworkExtensions.cs
+++ b/ModManager_Classes/Utils/FrameworkExtensions.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using Imya.Models.ModTweaker;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace Imya.Utils
 {
@@ -70,6 +72,56 @@ namespace Imya.Utils
             if (input is not null && !input.Contains('.'))
                 input += ".0";
             return Version.TryParse(input, out result);
+        }
+    }
+
+    public static class DictionaryEx
+    {
+        public static TValue? SafeGet<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey Key) where TKey : notnull
+        {
+            try
+            {
+                return dict[Key];
+            }
+            catch (Exception e)
+            {
+                return default(TValue);
+            }
+        }
+
+        public static TValue SafeAddOrGet<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey Key) where TKey : notnull where TValue : new()
+        {
+            if (dict.ContainsKey(Key)) return dict.SafeGet(Key)!;
+
+            TValue t = new();
+            dict.Add(Key, t);
+            return t;
+        }
+    }
+
+    public static class XmlNodeExtensions
+    {
+        public static bool HasAttribute(this XmlNode node, String AttribID)
+        {
+            return node.Attributes?[AttribID] is not null;
+        }
+
+        public static bool TryGetAttribute(this XmlNode node, String AttribID, out String? Value)
+        { 
+            Value = node.Attributes?[AttribID]?.Value;
+            return Value is not null;
+        }
+
+        public static bool TryGetModOpNode(this XmlDocument Document, String ModOpId, out XmlNode? ModOp)
+        {
+            ModOp = Document.SelectSingleNode($@"/ModOps/ModOp[@{TweakerConstants.MODOP_ID} = '{ModOpId}']");
+            return ModOp is not null;
+        }
+
+        public static bool TryGetModOpNodes(this XmlDocument Document, String ModOpId, out XmlNodeList? ModOps)
+        {
+            ModOps = Document.SelectNodes($@"/ModOps/ModOp[@{TweakerConstants.MODOP_ID} = '{ModOpId}']");
+            return ModOps is not null && ModOps.Count > 0;
         }
     }
 }


### PR DESCRIPTION
step towards resolving #44, #45

The reworked system is based on Include Directive and Skip Flag modloader features.  

- ImyaExpose links to multiple modops via ModOpID. 
- Customized values are stored in a different location (currently one central storage per mod), seperated from the mods themselves. That means we can install and reapply the values. 

### Exposes
- Path is relative to the ModOp code the modloader would apply. All nodes selected by it are considered for change. 
- Expose ID must be unique per-file to be stored in the central storage
- ModOp IDs are n to n. If multiple exposes modify the same modop, the last change may override the first.

### Exporting
- Skip the original modop
- Copy code of OG modop
- Apply Changes specified through exposes
- Save to a new file <name>.imyatweak.xml
- Include the new file via Include directive in the original file

Sample code how the modder would expose the maintenance cost of the gas heater.

```XML
<!-- Heater Maintenance: Best Practice example -->
  <ModOp GUID="8857100" Type="replace" Path="/Values/Maintenance/Maintenances/Item[Product='1010017']/Amount" ModOpID="Heater" Skip="1">
    <Amount>90</Amount>
  </ModOp>
  <ImyaExpose Path="self::Amount" ModOpID="Heater" ExposeID="CreditMaintenance" />
```

And this is the generated result
```XML
<ModOps>
  <ModOp Path="/Values/Maintenance/Maintenances/Item[Product='1010017']/Amount" GUID="8857100" Type="replace">
    <Amount>200</Amount>
  </ModOp>
</ModOps>
```