### PR TITLE
use git describe as product version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
         
       - name: Create Release
         id: create_release

--- a/ModManager/MainWindow.xaml.cs
+++ b/ModManager/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Reflection;
 using System.Windows;
 using Imya.UI.Properties;
 
@@ -23,7 +25,8 @@ namespace Imya.UI
             MinHeight = Settings.Default.MinWindowHeight;
             MinWidth = Settings.Default.MinWindowWidth;
 
-            Title = "iModYourAnno - Anno 1800 Mod Manager";
+            var productVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion ?? "?";
+            Title = $"iModYourAnno - Anno 1800 Mod Manager {productVersion}";
 
             MainViewController.SetView(View.MOD_ACTIVATION);
 #if DEBUG

--- a/ModManager/ModManager_Views.csproj
+++ b/ModManager/ModManager_Views.csproj
@@ -12,7 +12,23 @@
     <AssemblyName>iModYourAnno</AssemblyName>
     <StartupObject>Imya.UI.App</StartupObject>
     <DebugType>full</DebugType>
+
+    <!-- <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute> -->
+    <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
+
+  <!-- use git describe to set assembly version -->
+  <Target Name="SetGitVersion" BeforeTargets="InitializeSourceControlInformation">
+    <Exec Command="git describe --tags" ConsoleToMSBuild="True" IgnoreExitCode="False">
+      <Output PropertyName="GitDescribe" TaskParameter="ConsoleOutput"/>
+    </Exec>
+    <PropertyGroup>
+      <!-- <AssemblyVersion>$(GitDescribe)</AssemblyVersion> -->
+      <FileVersion>$(GitDescribe)</FileVersion>
+      <InformationalVersion>$(GitDescribe)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
 
   <ItemGroup>
     <None Remove="resources\dlc_icons\*.png" />


### PR DESCRIPTION
and display it in the title

Assembly version can't follow the same mechanism as it has a stricter version format, but the user doesn't see or care about it.

Closes #55 

Prints tag only for releases like `v0.1.0` or with commit count and hash like in the screenshot for intermediate builds.

![image](https://user-images.githubusercontent.com/12190313/166100308-9636c630-27af-49b1-8168-620a1b0445f9.png)