### PR TITLE
String formatting with multibinding

### DIFF
--- a/ModManager/ValueConverters/StringFormatConverter.cs
+++ b/ModManager/ValueConverters/StringFormatConverter.cs
@@ -14,6 +14,9 @@ namespace Imya.UI.ValueConverters
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             String? Text = values[0] as String;
+
+            if (Text is null) return String.Empty;
+
             return String.Format( Text, values.Skip(1).Take(values.Length -1).ToArray() );
         }
 

--- a/ModManager/ValueConverters/StringFormatConverter.cs
+++ b/ModManager/ValueConverters/StringFormatConverter.cs
@@ -1,0 +1,25 @@
+﻿using Imya.Models;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace Imya.UI.ValueConverters
+{
+    internal class StringFormatConverter : IMultiValueConverter 
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            String? Text = values[0] as String;
+            return String.Format( Text, values.Skip(1).Take(values.Length -1).ToArray() );
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/ModManager/Views/ModActivationView.xaml
+++ b/ModManager/Views/ModActivationView.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Imya.UI.Views"
              xmlns:Components="clr-namespace:Imya.UI.Components"
+             xmlns:Converters="clr-namespace:Imya.UI.ValueConverters"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              d:DataContext="{d:DesignInstance Type=local:ModActivationView}"
              mc:Ignorable="d" 
@@ -20,18 +21,37 @@
             <ColumnDefinition/>
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
+        <Grid.Resources>
+            <Converters:StringFormatConverter x:Key="Format" />
+        </Grid.Resources>
         <StackPanel 
                 x:Name="UpperControls" 
                 Orientation="Horizontal"
                 VerticalAlignment="Center"
                 HorizontalAlignment="Center"
-            Grid.ColumnSpan="2">
-            <TextBlock FontSize="15" Text="{Binding TextManager[MODLIST_ACTIVE].Text, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource IMYA_TEXT}"/>
+                Grid.ColumnSpan="2">
+            <TextBlock Style="{StaticResource IMYA_TEXT}"
+                       FontSize="15">
+                <TextBlock.Text>
+                    <MultiBinding Converter="{StaticResource Format}"
+                                  UpdateSourceTrigger="PropertyChanged">
+                        <Binding Path="TextManager[ACTIVATION_HEADER_FORMATTED].Text"
+                                 UpdateSourceTrigger="PropertyChanged" />
+                        <Binding Path="Mods.ActiveMods"
+                                 UpdateSourceTrigger="PropertyChanged" />
+                        <Binding Path="Mods.ActiveSizeInMBs"
+                                 UpdateSourceTrigger="PropertyChanged" />
+                        <Binding Path="Mods.DisplayedMods.Count"
+                                 UpdateSourceTrigger="PropertyChanged" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+            <!--<TextBlock FontSize="15" Text="{Binding TextManager[MODLIST_ACTIVE].Text, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource IMYA_TEXT}"/>
             <TextBlock FontSize="15" Text="{Binding Mods.ActiveMods, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource IMYA_TEXT}"/>
             <TextBlock FontSize="15" Text="{Binding TextManager[MODLIST_ACTIVE_SIZE].Text, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource IMYA_TEXT}"/>
             <TextBlock FontSize="15" Text="{Binding Mods.ActiveSizeInMBs, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource IMYA_TEXT}"/>
             <TextBlock FontSize="15" Text="{Binding TextManager[MODLIST_TOTAL].Text, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource IMYA_TEXT}"/>
-            <TextBlock FontSize="15" Text="{Binding Mods.DisplayedMods.Count, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource IMYA_TEXT}"/>
+            <TextBlock FontSize="15" Text="{Binding Mods.DisplayedMods.Count, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource IMYA_TEXT}"/>-->
         </StackPanel>
 
         <Components:ModList Grid.Row="1" Margin="0,5,5,5" Grid.Column="0" x:Name="ModList" />

--- a/ModManager/resources/texts.json
+++ b/ModManager/resources/texts.json
@@ -1000,6 +1000,19 @@
     "Spanish": null,
     "Taiwanese": null
   },
+  "ACTIVATION_HEADER_FORMATTED": {
+    "Chinese": null,
+    "English": "Active: {0}, ({1} MB), Available: {2}",
+    "French": null,
+    "German": "Aktiviert: {0}, ({1} MB), Installiert: {2}",
+    "Italian": null,
+    "Japanese": null,
+    "Korean": null,
+    "Polish": null,
+    "Russian": null,
+    "Spanish": null,
+    "Taiwanese": null
+  },
   "INSTALL_ALLOW_OLD_TO_OVERWRITE": {
     "Chinese": null,
     "English": "Allow old versions to overwrite new",


### PR DESCRIPTION
Adds a StringFormatConverter for Multibindings which takes the first value as String and then formats in the other values in using the default String.Format() method. 

Sample usage on a textblock: 

```XAML
<TextBlock Style="{StaticResource IMYA_TEXT}"
            FontSize="15">
    <TextBlock.Text>
        <MultiBinding Converter="{StaticResource Format}"
                        UpdateSourceTrigger="PropertyChanged">
            <Binding Path="TextManager[ACTIVATION_HEADER_FORMATTED].Text"
                        UpdateSourceTrigger="PropertyChanged" />
            <Binding Path="Mods.ActiveMods"
                        UpdateSourceTrigger="PropertyChanged" />
            <Binding Path="Mods.ActiveSizeInMBs"
                        UpdateSourceTrigger="PropertyChanged" />
            <Binding Path="Mods.DisplayedMods.Count"
                        UpdateSourceTrigger="PropertyChanged" />
        </MultiBinding>
    </TextBlock.Text>
</TextBlock>
```

closes #78 