### PR TITLE
fix activate button text

### DIFF
--- a/ModManager/resources/texts.json
+++ b/ModManager/resources/texts.json
@@ -103,7 +103,7 @@
     "Spanish": null,
     "Taiwanese": null
   },
-  "MODLIST_ACTIVE": {
+  "MODLIST_ACTIVATE": {
     "Chinese": null,
     "English": "Activate",
     "French": null,


### PR DESCRIPTION
Seems I made a mistake while I was deleting the old mod count header text.