### PR TITLE
activate modloader by default on startup

### DIFF
--- a/ModManager_Classes/Utils/GameSetupManager.cs
+++ b/ModManager_Classes/Utils/GameSetupManager.cs
@@ -96,7 +96,7 @@ namespace Imya.Utils
                 OnPropertyChanged(nameof(ModloaderActivationDesiredOnStart));
             }
         }
-        private bool _modloaderActivationDesiredOnStart; 
+        private bool _modloaderActivationDesiredOnStart = true; 
 
         public bool IsModloaderInstalled => ModloaderState == ModloaderInstallationState.Installed;
 


### PR DESCRIPTION
I was quite confused by the toggle. It's deactivated by default and deactivated state is also more colorful than activated state.

This PR only activates the toggle by default.

 A proper change should improve the styling and best also change the text based on the state.