### PR TITLE
add test: delete mod outside of the app

### DIFF
--- a/ModManager_Classes/Models/Attributes/IAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/IAttribute.cs
@@ -13,7 +13,9 @@ namespace Imya.Models.Attributes
         UnresolvedDependencyIssue,
         TweakedMod,
         MissingModinfo,
-        ModContentInSubfolder
+        ModContentInSubfolder,
+        IssueModRemoved,
+        IssueModAccess
     }
 
     public interface IAttribute

--- a/ModManager_Classes/Models/Mod.cs
+++ b/ModManager_Classes/Models/Mod.cs
@@ -27,7 +27,7 @@ namespace Imya.Models
         public bool IsActive
         {
             get => _isActive;
-            set
+            private set
             {
                 _isActive = value;
                 OnPropertyChanged(nameof(IsActive));
@@ -194,9 +194,18 @@ namespace Imya.Models
                     var verb = active ? "Activate" : "Deactivate";
                     Console.WriteLine($"{verb} {FolderName}. Folder renamed to {FullFolderName}");
                 }
+                catch (DirectoryNotFoundException)
+                {
+                    // TODO invoking stats change is stretching it
+                    Attributes.AddAttribute(new GenericAttribute() { AttributeType = AttributeType.IssueModRemoved, Description = SimpleText.Empty });
+                    StatsChanged?.Invoke();
+                    Console.WriteLine($"Mod not found: {FolderName}");
+                }
                 catch (Exception e)
                 {
                     var verb = active ? "activate" : "deactivate";
+                    Attributes.AddAttribute(new GenericAttribute() { AttributeType = AttributeType.IssueModAccess, Description = SimpleText.Empty });
+                    StatsChanged?.Invoke();
                     Console.WriteLine($"Failed to {verb} mod: {FolderName}. Cause: {e.Message}");
                 }
             });

--- a/ModManager_Classes/Texts/SimpleText.cs
+++ b/ModManager_Classes/Texts/SimpleText.cs
@@ -10,6 +10,8 @@ namespace Imya.Models
 {
     public class SimpleText : PropertyChangedNotifier, IText
     {
+        public readonly static SimpleText Empty = new(string.Empty);
+
         public String Text { 
             get => _text; 
             set

--- a/tests/Imya.UnitTests/ExternalAccessTests.cs
+++ b/tests/Imya.UnitTests/ExternalAccessTests.cs
@@ -1,0 +1,43 @@
+﻿using Imya.Models;
+using Imya.Models.Attributes;
+using Imya.UnitTests.Models;
+using Imya.Utils;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Imya.UnitTests
+{
+    public class ExternalAccessTests
+    {
+        public ExternalAccessTests()
+        {
+            // TODO going via side effects is not a good idea
+            AttributeCollectionFactory.AttributeCollectionType = typeof(TestAttributeCollection);
+        }
+
+        [Fact]
+        public async Task DeleteMod()
+        {
+            DirectoryEx.EnsureDeleted(@"tmp\ExternalAccessTests");
+
+            // prepare a mod
+            const string folder = @"tmp\ExternalAccessTests\mods\[a] mod1";
+            Directory.CreateDirectory(folder);
+            var mods = new ModCollection(@"tmp\ExternalAccessTests\mods");
+            mods.LoadModsAsync().Wait();
+
+            // check
+            Assert.Single(mods.Mods);
+
+            // delete mod
+            DirectoryEx.EnsureDeleted(@"tmp\ExternalAccessTests\mods\[a] mod1");
+
+            // deactivate deleted mod
+            await mods.Mods[0].ChangeActivationAsync(false);
+
+            // mod should be removed now
+            Assert.Empty(mods.Mods);
+        }
+    }
+}


### PR DESCRIPTION
First test to harden the app against external influence.

Turns out the only way changes in `Mod` are sent via `StatsChanged` events to the mod collection.
It looks like having something like a `ParentCollection` maybe a good idea, or more detailed events.

Fixed behavior:
- Activate/deactivate removes a mod from the list when the folder is missing. 