### PR TITLE
add more events to `Mod` like attribute changed and clean-up

### DIFF
--- a/ModManager/Views/Models/ObservableAttributeCollection.cs
+++ b/ModManager/Views/Models/ObservableAttributeCollection.cs
@@ -13,6 +13,9 @@ namespace Imya.UI.Models
     {
         public void AddAttribute(IAttribute attrib)
         {
+            if (!attrib.MultipleAllowed && this.Any(x => x.AttributeType == attrib.AttributeType))
+                return;
+
             App.Current.Dispatcher.Invoke(() => this.Add(attrib));
         }
 

--- a/ModManager_Classes/Models/Attributes/ConcreteAttributes/GenericAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/ConcreteAttributes/GenericAttribute.cs
@@ -10,5 +10,7 @@ namespace Imya.Models.Attributes
     {
         public AttributeType AttributeType { get; init; }
         public IText Description { get; init; }
+
+        bool IAttribute.MultipleAllowed => false;
     }
 }

--- a/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModCompabilityIssueAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModCompabilityIssueAttribute.cs
@@ -7,6 +7,8 @@ namespace Imya.Models.Attributes
         public AttributeType AttributeType { get; } = AttributeType.ModCompabilityIssue;
         public IText Description { get => new SimpleText(String.Format(TextManager.Instance.GetText("ATTRIBUTE_COMPABILITYERROR").Text, String.Join(',', CompabilityIssues.Select(x => $"{x.Category} {x.Name}")))); }
 
+        bool IAttribute.MultipleAllowed => true;
+
         public IEnumerable<Mod> CompabilityIssues { get; }
 
         public ModCompabilityIssueAttribute(IEnumerable<Mod> issues)

--- a/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModDependencyIssueAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModDependencyIssueAttribute.cs
@@ -12,6 +12,8 @@ namespace Imya.Models.Attributes
         public AttributeType AttributeType { get; } = AttributeType.UnresolvedDependencyIssue;
         public IText Description { get => new SimpleText(String.Format(TextManager.Instance.GetText("ATTRIBUTE_MISSINGDEPENDENCY").Text, String.Join(',', UnresolvedDependencies))); }
 
+        bool IAttribute.MultipleAllowed => true;
+
         public IEnumerable<String> UnresolvedDependencies { get; }
 
         public ModDependencyIssueAttribute(IEnumerable<String> issues)

--- a/ModManager_Classes/Models/Attributes/IAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/IAttribute.cs
@@ -8,17 +8,19 @@ namespace Imya.Models.Attributes
 {
     public enum AttributeType
     {
-        ModStatus,
-        ModCompabilityIssue,
-        UnresolvedDependencyIssue,
-        TweakedMod,
-        MissingModinfo,
-        ModContentInSubfolder
+        ModStatus = 0,
+        ModCompabilityIssue = 1,
+        UnresolvedDependencyIssue = 2,
+        TweakedMod = 3,
+        MissingModinfo = 4,
+        ModContentInSubfolder = 5
     }
 
     public interface IAttribute
     {
         AttributeType AttributeType { get; }
         IText Description { get; }
+
+        bool MultipleAllowed { get; }
     }
 }

--- a/tests/Imya.UnitTests/AttributeTests.cs
+++ b/tests/Imya.UnitTests/AttributeTests.cs
@@ -1,0 +1,36 @@
+﻿using Imya.Models.Attributes;
+using Imya.UnitTests.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Imya.UnitTests
+{
+    public class AttributeTests
+    {
+        [Fact]
+        public void AllowMultiple()
+        {
+            TestAttributeCollection attributes = new();
+
+            attributes.AddAttribute(new ModCompabilityIssueAttribute());
+            attributes.AddAttribute(new ModCompabilityIssueAttribute());
+
+            Assert.Equal(2, attributes.Count());
+        }
+
+        [Fact]
+        public void DontAllowMultiple()
+        {
+            TestAttributeCollection attributes = new();
+
+            attributes.AddAttribute(new GenericAttribute());
+            attributes.AddAttribute(new GenericAttribute());
+
+            Assert.Single(attributes);
+        }
+    }
+}


### PR DESCRIPTION
When the user deletes a mod via file explorer and then does actions on the mod via manager, the `Mod` class is the one who will notice issues - even with a file watcher.

Relates to #38 

It already has `StatsChanged` event, it should fire other events as well.
`StatsChanged` is not fired in UI thread, hence neither should a `AttributeChanged` nor the ObservableCollection that is currently used for it.

(draft, more commits to come. meant as a heads up)