### PR TITLE
detect when mod was externally deleted

### DIFF
--- a/ModManager/App.xaml.cs
+++ b/ModManager/App.xaml.cs
@@ -17,8 +17,10 @@ namespace Imya.UI
     /// </summary>
     public partial class App : Application
     {
-       public App()
-       {
+        private ModCollectionHooks _hooks;
+
+        public App()
+        {
             // load localized text first
             var text = TextManager.Instance;
             text.LoadLanguageFile(Settings.Default.LanguageFilePath);
@@ -33,7 +35,7 @@ namespace Imya.UI
 
             // init global mods
             ModCollection.Global = new ModCollection(gameSetup.GetModDirectory(), normalize: true, loadImages: true);
-            ModCollectionHooks.Initialize();
+            _hooks = new(ModCollection.Global);
             Task.Run(() => ModCollection.Global.LoadModsAsync());
         }
     }

--- a/ModManager/ModManager_Views.csproj
+++ b/ModManager/ModManager_Views.csproj
@@ -176,8 +176,4 @@
     </Page>
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Views\Models\" />
-  </ItemGroup>
-
 </Project>

--- a/ModManager/Models/BindableMod.cs
+++ b/ModManager/Models/BindableMod.cs
@@ -11,6 +11,7 @@ namespace Imya.UI.Models
     public class BindableMod : Bindable<Mod>
     {
         public bool IsActive => Model.IsActive;
+        public bool IsRemoved => Model.IsRemoved;
         public IText Name => Model.Name;
         public IText Category => Model.Category;
         public BindableCollection<IAttribute> Attributes { get; private set; }

--- a/ModManager/ValueConverters/AttributeConverters.cs
+++ b/ModManager/ValueConverters/AttributeConverters.cs
@@ -21,6 +21,8 @@ namespace Imya.UI.ValueConverters
                 AttributeType.TweakedMod => ("Tools", FindResourceBrush("InformationColorBrush")),
                 AttributeType.MissingModinfo => ("HelpBox", FindResourceBrush("InformationColorBrush")),
                 AttributeType.ModContentInSubfolder => ("AlertBox", FindResourceBrush("ErrorColorBrush")),
+                AttributeType.IssueModRemoved => ("RemoveCircleOutline", FindResourceBrush("ErrorColorBrush")),
+                AttributeType.IssueModAccess => ("RemoveCircleOutline", FindResourceBrush("ErrorColorBrush")),
                 _ => ("InformationOutline", FindResourceBrush("TextColorBrush")),
             };
         }

--- a/ModManager/ValueConverters/AttributeConverters.cs
+++ b/ModManager/ValueConverters/AttributeConverters.cs
@@ -21,8 +21,8 @@ namespace Imya.UI.ValueConverters
                 AttributeType.TweakedMod => ("Tools", FindResourceBrush("InformationColorBrush")),
                 AttributeType.MissingModinfo => ("HelpBox", FindResourceBrush("InformationColorBrush")),
                 AttributeType.ModContentInSubfolder => ("AlertBox", FindResourceBrush("ErrorColorBrush")),
-                AttributeType.IssueModRemoved => ("RemoveCircleOutline", FindResourceBrush("ErrorColorBrush")),
-                AttributeType.IssueModAccess => ("RemoveCircleOutline", FindResourceBrush("ErrorColorBrush")),
+                AttributeType.IssueModRemoved => ("TrashCanOutline", FindResourceBrush("ErrorColorBrush")),
+                AttributeType.IssueModAccess => ("FolderAlertOutline", FindResourceBrush("ErrorColorBrush")),
                 _ => ("InformationOutline", FindResourceBrush("TextColorBrush")),
             };
         }

--- a/ModManager/Views/Components/ModList.xaml
+++ b/ModManager/Views/Components/ModList.xaml
@@ -90,11 +90,13 @@
                             <ColumnDefinition Width="auto" />
                         </Grid.ColumnDefinitions>
                         <materialDesign:PackIcon 
+                            Name="ModActivationIcon"
                             VerticalAlignment="Center"
                             Margin="5,0"
                             Kind="{Binding IsActive, Converter={StaticResource ModIconConverter}}"
                             Foreground="{Binding IsActive, Converter={StaticResource ModIconColorConverter}, UpdateSourceTrigger=PropertyChanged}" />
                         <Grid
+                            Name="ModEntry"
                             VerticalAlignment="Center"
                             Grid.Column="1"
                             Margin="0,3">
@@ -103,15 +105,15 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
-                                Text="{Binding Category.Text}"
+                                Name="ModCategoryName"
                                 Style="{StaticResource IMYA_TEXT}"
-                                FontWeight="ExtraBold" />
-                            <TextBlock 
-                                Grid.Column="1"
-                                Margin="5,0,0,0"
-                                Text="{Binding Name.Text}"
-                                Style="{StaticResource IMYA_TEXT}"
-                                TextWrapping="WrapWithOverflow" />
+                                TextWrapping="WrapWithOverflow">
+                                <Run
+                                    Text="{Binding Category.Text, Mode=OneWay}"
+                                    FontWeight="ExtraBold" />
+                                <Run
+                                    Text="{Binding Name.Text, Mode=OneWay}" />
+                            </TextBlock>
                         </Grid>
                         <ItemsControl 
                             ItemsSource="{Binding Attributes}"
@@ -139,6 +141,22 @@
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
                     </Grid>
+                    <DataTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsRemoved}" Value="True">
+                            <Setter
+                                TargetName="ModEntry"
+                                Property="Opacity"
+                                Value="0.5" />
+                            <Setter
+                                TargetName="ModCategoryName"
+                                Property="TextDecorations"
+                                Value="StrikeThrough" />
+                            <Setter
+                                TargetName="ModActivationIcon"
+                                Property="Visibility"
+                                Value="Hidden" />
+                        </DataTrigger>
+                    </DataTemplate.Triggers>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>

--- a/ModManager/Views/ModActivationView.xaml.cs
+++ b/ModManager/Views/ModActivationView.xaml.cs
@@ -5,6 +5,7 @@ using Imya.Utils;
 using System;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
@@ -72,13 +73,24 @@ namespace Imya.UI.Views
 
         private void OnDelete(object sender, RoutedEventArgs e)
         {
-            GenericOkayPopup dialog = new();
-            dialog.OK_TEXT = new SimpleText("Okay");
-            dialog.CANCEL_TEXT = new SimpleText("Cancel");
-            dialog.MESSAGE = new SimpleText("This will irreversibly delete all selected mods from the mods folder. Are you sure?");
-            dialog.ShowDialog();
+            bool hasModsWorthyAsking = ModList.CurrentlySelectedMods?.Any(x => !x.IsRemoved) ?? false;
+            bool deleteMods = !hasModsWorthyAsking;
 
-            if (dialog.DialogResult is true) ModList.DeleteSelection();
+            if (hasModsWorthyAsking)
+            {
+                GenericOkayPopup dialog = new()
+                {
+                    OK_TEXT = new SimpleText("Okay"),
+                    CANCEL_TEXT = new SimpleText("Cancel"),
+                    MESSAGE = new SimpleText("This will irreversibly delete all selected mods from the mods folder. Are you sure?")
+                };
+                dialog.ShowDialog();
+
+                deleteMods = dialog.DialogResult ?? false;
+            }
+
+            if (deleteMods)
+                ModList.DeleteSelection();
         }
 
         private async void LoadProfileClick(object sender, RoutedEventArgs e)

--- a/ModManager/Views/ModActivationView.xaml.cs
+++ b/ModManager/Views/ModActivationView.xaml.cs
@@ -64,11 +64,13 @@ namespace Imya.UI.Views
         private void OnActivate(object sender, RoutedEventArgs e)
         {
             ModList.ActivateSelection();
+            UpdateButtons();
         }
 
         private void OnDeactivate(object sender, RoutedEventArgs e)
         {
             ModList.DeactivateSelection();
+            UpdateButtons();
         }
 
         private void OnDelete(object sender, RoutedEventArgs e)
@@ -154,6 +156,12 @@ namespace Imya.UI.Views
             CanActivate = ModList.AnyInactiveSelected() && !GameSetupManager.Instance.IsGameRunning;
             CanDeactivate = ModList.AnyActiveSelected() && !GameSetupManager.Instance.IsGameRunning;
             CanDelete = ModList.HasSelection && !GameSetupManager.Instance.IsGameRunning;
+
+            if (ModList.CurrentlySelectedMods?.Where(x => x.IsRemoved).Count() == ModList.CurrentlySelectedMods?.Count())
+            {
+                CanActivate = false;
+                CanDeactivate = false;
+            }
 
             CanLoadProfile = !GameSetupManager.Instance.IsGameRunning;
         }

--- a/ModManager_Classes/Models/Attributes/AttributeCollection.cs
+++ b/ModManager_Classes/Models/Attributes/AttributeCollection.cs
@@ -8,6 +8,8 @@ namespace Imya.Models.Attributes
     {
         public void AddAttribute(IAttribute attrib)
         {
+            if (!attrib.MultipleAllowed && this.Any(x => x.AttributeType == attrib.AttributeType))
+                return;
             Add(attrib);
         }
 

--- a/ModManager_Classes/Models/Attributes/ConcreteAttributes/GenericAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/ConcreteAttributes/GenericAttribute.cs
@@ -10,5 +10,7 @@ namespace Imya.Models.Attributes
     {
         public AttributeType AttributeType { get; init; }
         public IText Description { get; init; }
+
+        bool IAttribute.MultipleAllowed => false;
     }
 }

--- a/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModCompabilityIssueAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModCompabilityIssueAttribute.cs
@@ -7,6 +7,8 @@ namespace Imya.Models.Attributes
         public AttributeType AttributeType { get; } = AttributeType.ModCompabilityIssue;
         public IText Description { get => new SimpleText(String.Format(TextManager.Instance.GetText("ATTRIBUTE_COMPABILITYERROR").Text, String.Join(',', CompabilityIssues.Select(x => $"{x.Category} {x.Name}")))); }
 
+        bool IAttribute.MultipleAllowed => true;
+
         public IEnumerable<Mod> CompabilityIssues { get; }
 
         public ModCompabilityIssueAttribute(IEnumerable<Mod> issues)

--- a/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModDependencyIssueAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModDependencyIssueAttribute.cs
@@ -12,6 +12,8 @@ namespace Imya.Models.Attributes
         public AttributeType AttributeType { get; } = AttributeType.UnresolvedDependencyIssue;
         public IText Description { get => new SimpleText(String.Format(TextManager.Instance.GetText("ATTRIBUTE_MISSINGDEPENDENCY").Text, String.Join(',', UnresolvedDependencies))); }
 
+        bool IAttribute.MultipleAllowed => true;
+
         public IEnumerable<String> UnresolvedDependencies { get; }
 
         public ModDependencyIssueAttribute(IEnumerable<String> issues)

--- a/ModManager_Classes/Models/Attributes/IAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/IAttribute.cs
@@ -8,12 +8,14 @@ namespace Imya.Models.Attributes
 {
     public enum AttributeType
     {
-        ModStatus = 0,
-        ModCompabilityIssue = 1,
-        UnresolvedDependencyIssue = 2,
-        TweakedMod = 3,
-        MissingModinfo = 4,
-        ModContentInSubfolder = 5
+        ModStatus,
+        ModCompabilityIssue,
+        UnresolvedDependencyIssue,
+        TweakedMod,
+        MissingModinfo,
+        ModContentInSubfolder,
+        IssueModRemoved,
+        IssueModAccess
     }
 
     public interface IAttribute

--- a/ModManager_Classes/Models/Attributes/IAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/IAttribute.cs
@@ -8,17 +8,19 @@ namespace Imya.Models.Attributes
 {
     public enum AttributeType
     {
-        ModStatus,
-        ModCompabilityIssue,
-        UnresolvedDependencyIssue,
-        TweakedMod,
-        MissingModinfo,
-        ModContentInSubfolder
+        ModStatus = 0,
+        ModCompabilityIssue = 1,
+        UnresolvedDependencyIssue = 2,
+        TweakedMod = 3,
+        MissingModinfo = 4,
+        ModContentInSubfolder = 5
     }
 
     public interface IAttribute
     {
         AttributeType AttributeType { get; }
         IText Description { get; }
+
+        bool MultipleAllowed { get; }
     }
 }

--- a/ModManager_Classes/Models/Attributes/ModAccessIssueAttributeFactory.cs
+++ b/ModManager_Classes/Models/Attributes/ModAccessIssueAttributeFactory.cs
@@ -1,0 +1,33 @@
+﻿using Imya.Utils;
+
+namespace Imya.Models.Attributes
+{
+    internal class ModAccessIssueAttributeFactory
+    {
+        static GenericAttribute ModAccessIssueAttribute =
+           new GenericAttribute()
+           {
+               AttributeType = AttributeType.IssueModAccess,
+               //Description = TextManager.Instance.GetText("ATTRIBUTE_NOMODINFO")
+               Description = IText.Empty
+           };
+
+        static GenericAttribute ModAccessIssue_NoDeleteAttribute =
+           new GenericAttribute()
+           {
+               AttributeType = AttributeType.IssueModAccess,
+               //Description = TextManager.Instance.GetText("ATTRIBUTE_NOMODINFO")
+               Description = new SimpleText("Could not delete this mod.")
+           };
+
+        public static IAttribute Get()
+        {
+            return ModAccessIssueAttribute;
+        }
+
+        public static IAttribute GetNoDelete()
+        {
+            return ModAccessIssue_NoDeleteAttribute;
+        }
+    }
+}

--- a/ModManager_Classes/Models/Attributes/ModAccessIssueAttributeFactory.cs
+++ b/ModManager_Classes/Models/Attributes/ModAccessIssueAttributeFactory.cs
@@ -9,7 +9,7 @@ namespace Imya.Models.Attributes
            {
                AttributeType = AttributeType.IssueModAccess,
                //Description = TextManager.Instance.GetText("ATTRIBUTE_NOMODINFO")
-               Description = IText.Empty
+               Description = new SimpleText("Access to the Folder is denied. Please close all programs accessing this folder and retry.")
            };
 
         static GenericAttribute ModAccessIssue_NoDeleteAttribute =

--- a/ModManager_Classes/Models/Attributes/RemovedFolderAttributeFactory.cs
+++ b/ModManager_Classes/Models/Attributes/RemovedFolderAttributeFactory.cs
@@ -1,0 +1,20 @@
+﻿using Imya.Utils;
+
+namespace Imya.Models.Attributes
+{
+    internal class RemovedFolderAttributeFactory
+    {
+        static GenericAttribute TweakedAttribute =
+            new GenericAttribute()
+            {
+                AttributeType = AttributeType.IssueModRemoved,
+                //Description = TextManager.Instance.GetText("ATTRIBUTE_TWEAKED")
+                Description = new SimpleText("This mod has been removed by another program")
+            };
+
+        public static IAttribute Get()
+        {
+            return TweakedAttribute;
+        }
+    }
+}

--- a/ModManager_Classes/Models/Mod.cs
+++ b/ModManager_Classes/Models/Mod.cs
@@ -47,7 +47,7 @@ namespace Imya.Models
                 if (IsRemoved == value)
                     return;
                 Attributes.Clear();
-                Attributes.AddAttribute(new GenericAttribute() { AttributeType = AttributeType.IssueModRemoved, Description = new SimpleText("This mod has been by another program.") });
+                Attributes.AddAttribute(RemovedFolderAttributeFactory.Get());
                 OnPropertyChanged(nameof(IsRemoved));
             }
         }
@@ -204,7 +204,7 @@ namespace Imya.Models
                 }
                 catch (Exception e)
                 {
-                    Attributes.AddAttribute(new GenericAttribute() { AttributeType = AttributeType.IssueModAccess, Description = SimpleText.Empty });
+                    Attributes.AddAttribute(ModAccessIssueAttributeFactory.Get());
                     Console.WriteLine($"Failed to {verb} mod: {FolderName}. Cause: {e.Message}");
                 }
             });

--- a/ModManager_Classes/Models/ModCollection.cs
+++ b/ModManager_Classes/Models/ModCollection.cs
@@ -343,7 +343,7 @@ namespace Imya.Models
                 }
                 catch (Exception e)
                 {
-                    mod.Attributes.Add(new GenericAttribute() { AttributeType = AttributeType.IssueModAccess, Description = new SimpleText("Could not delete this mod.") });
+                    mod.Attributes.Add(ModAccessIssueAttributeFactory.GetNoDelete());
                     Console.WriteLine($"Failed to delete Mod: {mod.Category} {mod.Name}. Cause: {e.Message}");
                 }
             });

--- a/ModManager_Classes/Models/ModCollection.cs
+++ b/ModManager_Classes/Models/ModCollection.cs
@@ -196,10 +196,13 @@ namespace Imya.Models
 
         private void OnActivationChanged(Mod? sender)
         {
-            var newActive = _mods.Count(x => x.IsActive);
-            //if (newActive != ActiveMods)
+            // remove mods with IssueModRemoved attribute
+            int removedModCount = _mods.Count(x => x.Attributes.HasAttribute(AttributeType.IssueModRemoved));
+
+            int newActiveCount = _mods.Count(x => x.IsActive);
+            if (removedModCount > 0 || ActiveMods != newActiveCount)
             {
-                ActiveMods = newActive;
+                ActiveMods = newActiveCount;
                 ActiveSizeInMBs = (int)Math.Round(_mods.Sum(x => x.IsActive ? x.SizeInMB : 0));
                 InstalledSizeInMBs = (int)Math.Round(_mods.Sum(x => x.SizeInMB));
                 Console.WriteLine($"{ActiveMods} active mods. {_mods.Count} total found.");
@@ -218,7 +221,7 @@ namespace Imya.Models
         /// Source collection folder will be deleted afterwards.
         /// Existing mods will be overwriten, old names with same mod id deactivated.
         /// </summary>
-        public async Task MoveIntoAsync(ModCollection source, bool AllowOldToOverwrite = false)
+        public async Task MoveIntoAsync(ModCollection source, bool allowOldToOverwrite = false)
         {
             Directory.CreateDirectory(ModsPath);
 
@@ -226,7 +229,7 @@ namespace Imya.Models
             {
                 foreach (var sourceMod in source.Mods)
                 {
-                    await MoveSingleModIntoAsync(sourceMod, source.ModsPath, AllowOldToOverwrite);
+                    await MoveSingleModIntoAsync(sourceMod, source.ModsPath, allowOldToOverwrite);
                 }
             }
             catch (Exception e)
@@ -241,11 +244,11 @@ namespace Imya.Models
             CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, Mods.ToList()));
         }
 
-        private async Task MoveSingleModIntoAsync(Mod sourceMod, String SourceModsPath, bool AllowOldToOverwrite)
+        private async Task MoveSingleModIntoAsync(Mod sourceMod, string sourceModsPath, bool allowOldToOverwrite)
         {
             var (targetMod, targetModPath) = SelectTargetMod(sourceMod);
 
-            if (!AllowOldToOverwrite && !sourceMod.IsUpdateOf(targetMod))
+            if (!allowOldToOverwrite && !sourceMod.IsUpdateOf(targetMod))
             {
                 Console.WriteLine($"Skip update of {sourceMod.FolderName}. Source version: {sourceMod.Modinfo.Version}, target version: {targetMod?.Modinfo.Version}");
                 return;
@@ -255,7 +258,7 @@ namespace Imya.Models
             var status = Directory.Exists(targetModPath) ? ModStatus.Updated : ModStatus.New;
             sourceMod.Attributes.AddAttribute(ModStatusAttributeFactory.Get(status));
 
-            DirectoryEx.CleanMove(Path.Combine(SourceModsPath, sourceMod.FullFolderName), targetModPath);
+            DirectoryEx.CleanMove(Path.Combine(sourceModsPath, sourceMod.FullFolderName), targetModPath);
             Console.WriteLine($"{sourceMod.Attributes.GetByType(AttributeType.ModStatus)}: {sourceMod.FolderName}");
 
             // mark all duplicate id mods as obsolete
@@ -332,8 +335,15 @@ namespace Imya.Models
                     _mods.Remove(mod);
                     mod.PropertyChanged -= Mod_PropertyChanged;
                 }
+                catch (DirectoryNotFoundException)
+                {
+                    // remove from the mod lists to prevent access.
+                    _mods.Remove(mod);
+                    mod.PropertyChanged -= Mod_PropertyChanged;
+                }
                 catch (Exception e)
                 {
+                    mod.Attributes.Add(new GenericAttribute() { AttributeType = AttributeType.IssueModAccess, Description = new SimpleText("Could not delete this mod.") });
                     Console.WriteLine($"Failed to delete Mod: {mod.Category} {mod.Name}. Cause: {e.Message}");
                 }
             });

--- a/ModManager_Classes/Models/NotifyPropertyChanged/PropertyChangedNotifier.cs
+++ b/ModManager_Classes/Models/NotifyPropertyChanged/PropertyChangedNotifier.cs
@@ -5,7 +5,7 @@ namespace Imya.Models.NotifyPropertyChanged
 {
     public abstract class PropertyChangedNotifier : INotifyPropertyChanged
     {
-        public event PropertyChangedEventHandler? PropertyChanged = delegate { };
+        public event PropertyChangedEventHandler? PropertyChanged;
         protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         protected void SetProperty<T>(ref T property, T value, [CallerMemberName] string propertyName = "")
         {

--- a/ModManager_Classes/Texts/SimpleText.cs
+++ b/ModManager_Classes/Texts/SimpleText.cs
@@ -10,6 +10,8 @@ namespace Imya.Models
 {
     public class SimpleText : PropertyChangedNotifier, IText
     {
+        public readonly static SimpleText Empty = new(string.Empty);
+
         public String Text { 
             get => _text; 
             set

--- a/ModManager_Classes/Validation/ModCollectionHooks.cs
+++ b/ModManager_Classes/Validation/ModCollectionHooks.cs
@@ -13,12 +13,9 @@ namespace Imya.Validation
                 new ModCompatibilityValidator()
             };
 
-        private ModCollectionHooks()
+        public ModCollectionHooks(ModCollection mods)
         {
-            if (ModCollection.Global is null)
-                throw new Exception("ModCollection.Global is null. Should not happen, hence something is very wrong.");
-
-            ModCollection.Global.CollectionChanged += ValidateOnChange;
+            mods.CollectionChanged += ValidateOnChange;
         }
 
         private void ValidateOnChange(object? sender, NotifyCollectionChangedEventArgs e)
@@ -35,11 +32,6 @@ namespace Imya.Validation
                 foreach (var mod in changed)
                     UpdateWithTweak(mod);
             }
-        }
-
-        public static void Initialize()
-        {
-            new ModCollectionHooks();
         }
 
         private static void UpdateWithTweak(Mod mod)

--- a/ModManager_Classes/Validation/ModCompatibilityValidator.cs
+++ b/ModManager_Classes/Validation/ModCompatibilityValidator.cs
@@ -18,7 +18,7 @@ namespace Imya.Validation
             mod.Attributes.RemoveAttributesByType(AttributeType.ModCompabilityIssue);
 
             // skip dependency check if inactive or standalone
-            if (!mod.IsActive || collection is null)
+            if (!mod.IsActiveAndValid || collection is null)
                 return;
 
             var unresolvedDeps = GetUnresolvedDependencies(mod.Modinfo, collection);
@@ -37,7 +37,7 @@ namespace Imya.Validation
 
             foreach (var dep in modinfo.ModDependencies)
             {
-                if (!collection.Any(x => x.Modinfo.ModID is not null && x.Modinfo.ModID.Equals(dep) && x.IsActive))
+                if (!collection.Any(x => x.Modinfo.ModID is not null && x.Modinfo.ModID.Equals(dep) && x.IsActiveAndValid))
                     yield return dep;
             }
         }
@@ -49,7 +49,7 @@ namespace Imya.Validation
             
             foreach (var inc in modinfo.IncompatibleIds)
             {
-                var incompatibles = collection.Where(x => x.Modinfo.ModID is not null && x.Modinfo.ModID.Equals(inc) && x.IsActive);
+                var incompatibles = collection.Where(x => x.Modinfo.ModID is not null && x.Modinfo.ModID.Equals(inc) && x.IsActiveAndValid);
                 foreach (var result in incompatibles)
                     yield return result;
             }

--- a/ModManager_Classes/Validation/ModContentValidator.cs
+++ b/ModManager_Classes/Validation/ModContentValidator.cs
@@ -20,6 +20,12 @@ namespace Imya.Validation
         {
             mod.Attributes.RemoveAttributesByType(AttributeType.ModContentInSubfolder);
 
+            if (mod.IsRemoved || !Directory.Exists(mod.FullModPath))
+            {
+                mod.IsRemoved = true;
+                return;
+            }
+
             string dataPath = Path.Combine(mod.FullModPath, "data");
             if (!Directory.Exists(dataPath))
             {

--- a/tests/Imya.UnitTests/AttributeTests.cs
+++ b/tests/Imya.UnitTests/AttributeTests.cs
@@ -1,0 +1,30 @@
+﻿using Imya.Models.Attributes;
+using Xunit;
+
+namespace Imya.UnitTests
+{
+    public class AttributeTests
+    {
+        [Fact]
+        public void AllowMultiple()
+        {
+            AttributeCollection attributes = new();
+
+            attributes.AddAttribute(new ModCompabilityIssueAttribute());
+            attributes.AddAttribute(new ModCompabilityIssueAttribute());
+
+            Assert.Equal(2, attributes.Count);
+        }
+
+        [Fact]
+        public void DontAllowMultiple()
+        {
+            AttributeCollection attributes = new();
+
+            attributes.AddAttribute(new GenericAttribute());
+            attributes.AddAttribute(new GenericAttribute());
+
+            Assert.Single(attributes);
+        }
+    }
+}

--- a/tests/Imya.UnitTests/ExternalAccessTests.cs
+++ b/tests/Imya.UnitTests/ExternalAccessTests.cs
@@ -1,0 +1,170 @@
+﻿using Imya.Models;
+using Imya.Utils;
+using Imya.Validation;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Imya.UnitTests
+{
+    public class ExternalAccessTests
+    {
+        [Fact]
+        public async Task ChangeActivationOnDeletedMod()
+        {
+            const string test = $@"temp\{nameof(ChangeActivationOnDeletedMod)}";
+            DirectoryEx.EnsureDeleted(test);
+
+            // prepare a mod
+            const string folder = $@"{test}\mods\[a] mod1";
+            Directory.CreateDirectory(folder);
+            var mods = new ModCollection($@"{test}\mods");
+            await mods.LoadModsAsync();
+
+            // check
+            Assert.Single(mods);
+
+            // delete mod
+            DirectoryEx.EnsureDeleted(folder);
+
+            // deactivate deleted mod
+            await mods.Mods[0].ChangeActivationAsync(false);
+
+            // mod should be still in the list, but marked as removed
+            Assert.Single(mods);
+            Assert.True(mods.Mods[0].IsRemoved);
+            Assert.True(mods.Mods[0].Attributes.HasAttribute(Models.Attributes.AttributeType.IssueModRemoved));
+            Assert.Single(mods.Mods[0].Attributes);
+
+            // activation state should be unchanged
+            Assert.True(mods.Mods[0].IsActive);
+        }
+
+        [Fact]
+        public async Task ValidateOnDeletedMod()
+        {
+            const string test = $@"temp\{nameof(ValidateOnDeletedMod)}";
+            DirectoryEx.EnsureDeleted(test);
+
+            // prepare a mod
+            const string folderA = $@"{test}\mods\[a] mod A";
+            Directory.CreateDirectory(folderA);
+            File.WriteAllText($@"{folderA}\modinfo.json", @"{""ModID"": ""modA""}");
+            const string folderB = $@"{test}\mods\[a] mod B";
+            Directory.CreateDirectory(folderB);
+            File.WriteAllText($@"{folderB}\modinfo.json", @"{""ModID"": ""modB"", ""ModDependencies"": [ ""modA"" ]}");
+            const string folderC = $@"{test}\mods\[a] mod C";
+            Directory.CreateDirectory(folderC);
+            var mods = new ModCollection($@"{test}\mods");
+            await mods.LoadModsAsync();
+
+            // check
+            Assert.Equal(3, mods.Count);
+
+            // delete mod
+            DirectoryEx.EnsureDeleted(folderA);
+
+            // deactivate deleted mod to trigger IsRemoved=true
+            Mod modA = mods.Mods.Where(x => x.Name.Text == "mod A").First();
+            modA.IsRemoved = true;
+
+            // trigger validation by deleting mod3
+            ModCollectionHooks hooks = new(mods);
+            await mods.DeleteAsync(mods.Mods.Where(x => x.Name.Text == "mod C").ToArray());
+            Assert.Equal(2, mods.Count);
+
+            // mod B should have dependency issue
+            Mod modB = mods.Mods.Where(x => x.Name.Text == "mod B").First();
+            Assert.True(modB.Attributes.HasAttribute(Models.Attributes.AttributeType.UnresolvedDependencyIssue));
+        }
+
+        [Fact]
+        public async Task InstallDeletedMod()
+        {
+            const string test = $@"temp\{nameof(InstallDeletedMod)}";
+            DirectoryEx.EnsureDeleted(test);
+
+            // prepare a mod
+            const string folderA = $@"{test}\mods\[a] mod1";
+            Directory.CreateDirectory(folderA);
+            var mods = new ModCollection($@"{test}\mods");
+            await mods.LoadModsAsync();
+
+            // prepare reinstall mod
+            const string folderB = $@"{test}\mods2\[a] mod1";
+            Directory.CreateDirectory(folderB);
+            var modsInstall = new ModCollection($@"{test}\mods2");
+            await modsInstall.LoadModsAsync();
+
+            // check
+            Assert.Single(mods);
+            DirectoryEx.EnsureDeleted(folderA);
+            await mods.Mods[0].ChangeActivationAsync(false);
+            Assert.Single(mods);
+            Assert.True(mods.Mods[0].IsRemoved);
+
+            // reinstall
+            await mods.MoveIntoAsync(modsInstall);
+
+            // should be active mod now
+            Assert.Single(mods);
+            Assert.False(mods.Mods[0].IsRemoved);
+            Assert.False(mods.Mods[0].Attributes.HasAttribute(Models.Attributes.AttributeType.IssueModRemoved));
+            Assert.True(mods.Mods[0].IsActive);
+            // check reevaluation of things like modinfo.json
+            Assert.True(mods.Mods[0].Attributes.HasAttribute(Models.Attributes.AttributeType.MissingModinfo));
+        }
+
+        [Fact]
+        public async Task DeleteDeletedMod()
+        {
+            const string test = $@"temp\{nameof(DeleteDeletedMod)}";
+            DirectoryEx.EnsureDeleted(test);
+
+            // prepare a mod
+            const string folderA = $@"{test}\mods\[a] mod1";
+            Directory.CreateDirectory(folderA);
+            var mods = new ModCollection($@"{test}\mods");
+            await mods.LoadModsAsync();
+
+            // check
+            Assert.Single(mods);
+            DirectoryEx.EnsureDeleted(folderA);
+            await mods.Mods[0].ChangeActivationAsync(false);
+            Assert.Single(mods);
+            Assert.True(mods.Mods[0].IsRemoved);
+
+            // delete
+            await mods.DeleteAsync(mods.ToArray());
+
+            // should be deleted now
+            Assert.Empty(mods);
+        }
+
+        [Fact]
+        public async Task DeleteDeletedModNoTrigger()
+        {
+            const string test = $@"{nameof(DeleteDeletedModNoTrigger)}";
+            DirectoryEx.EnsureDeleted(test);
+
+            // prepare a mod
+            const string folderA = $@"{test}\mods\[a] mod1";
+            Directory.CreateDirectory(folderA);
+            var mods = new ModCollection($@"{test}\mods");
+            await mods.LoadModsAsync();
+
+            // check
+            Assert.Single(mods);
+            DirectoryEx.EnsureDeleted(folderA);
+            Assert.Single(mods);
+            Assert.False(mods.Mods[0].IsRemoved);
+
+            // delete
+            await mods.DeleteAsync(mods.ToArray());
+
+            // should be deleted now
+            Assert.Empty(mods);
+        }
+    }
+}

--- a/tests/Imya.UnitTests/ModCollectionTests.cs
+++ b/tests/Imya.UnitTests/ModCollectionTests.cs
@@ -425,7 +425,7 @@ namespace Imya.UnitTests
             source.LoadModsAsync().Wait();
 
             // target should not be overwritten
-            target.MoveIntoAsync(source, AllowOldToOverwrite: true).Wait();
+            target.MoveIntoAsync(source, allowOldToOverwrite: true).Wait();
             Assert.Equal(ModStatus.Updated, target.Mods.First().GetStatus());
             Assert.Equal("{\"Version\": \"1\"}", File.ReadAllText($"{targetMod}\\modinfo.json"));
 
@@ -436,7 +436,7 @@ namespace Imya.UnitTests
             source.LoadModsAsync().Wait();
 
             // target should not be overwritten
-            target.MoveIntoAsync(source, AllowOldToOverwrite: true).Wait();
+            target.MoveIntoAsync(source, allowOldToOverwrite: true).Wait();
             Assert.Equal(ModStatus.Updated, target.Mods.First().GetStatus());
             Assert.Equal("{\"Version\": null}", File.ReadAllText($"{targetMod}\\modinfo.json"));
         }


### PR DESCRIPTION
Actions like deactivate will trigger a check and mark mods as removed when their folder doesn't exist anymore.

Properly updated on reinstall or delete actions. Delete won't ask for confirmation in this case.

![image](https://user-images.githubusercontent.com/12190313/188721060-7e518e70-1ef2-444f-b36d-15b495f1e7a9.png)
