### PR TITLE
Improve obsolete mod handling

### DIFF
--- a/ModManager_Classes/Models/Mod.cs
+++ b/ModManager_Classes/Models/Mod.cs
@@ -75,6 +75,8 @@ namespace Imya.Models
         public LocalizedModinfo Modinfo { get; private init; }
         public ImyaImageSource? Image { get; private set; }
 
+        public Version? Version { get; private init; }
+
         public bool HasVersion { get => Modinfo.Version is not null; }
         public bool HasDescription { get => Modinfo.Description is not null; }
         public bool HasKnownIssues { get => Modinfo.KnownIssues is not null && Modinfo.KnownIssues.Length > 0; }
@@ -130,6 +132,9 @@ namespace Imya.Models
                 Image = new ImyaImageSource();
                 Image.ConstructAsBase64Image(Modinfo.Image);
             }
+
+            if (VersionEx.TryParse(Modinfo.Version, out var version))
+                Version = version;
 
             // Just get the size
             // TODO move to separate async?
@@ -301,24 +306,19 @@ namespace Imya.Models
                 return false;
 
             // compare content when unversioned
-            if (target.Modinfo.Version is null && Modinfo.Version is null)
+            if (target.Version is null && Version is null)
                 return !HasSameContentAs(target); // consider same as outdated
 
             // prefer versioned mods
-            if (target.Modinfo.Version is null)
+            if (target.Version is null)
                 return true;
-            if (Modinfo.Version is null)
+            if (Version is null)
                 return false;
 
-            // can't compare not parsable versions
-            if (!VersionEx.TryParse(target.Modinfo.Version, out var targetVersion) ||
-                !VersionEx.TryParse(Modinfo.Version, out var sourceVersion))
+            if (Version == target.Version)
                 return !HasSameContentAs(target); // consider same as outdated
 
-            if (sourceVersion == targetVersion)
-                return !HasSameContentAs(target); // consider same as outdated
-
-            return sourceVersion > targetVersion;
+            return Version > target.Version;
         }
         #endregion
 

--- a/ModManager_Classes/Models/ModCollection.cs
+++ b/ModManager_Classes/Models/ModCollection.cs
@@ -272,6 +272,14 @@ namespace Imya.Models
                     status = ModStatus.Updated;
             }
 
+            // mark deprecated ids as obsolete
+            if (sourceMod.Modinfo.DeprecateIds != null)
+            {
+                var deprecateIDs = sourceMod.Modinfo.DeprecateIds.SelectMany(x => WhereByModID(x));
+                foreach (var mod in deprecateIDs)
+                    await mod.MakeObsoleteAsync(ModsPath);
+            }
+
             // update mod list, only remove in case of same folder
             if (targetMod is not null)
             {

--- a/ModManager_Classes/Models/ModMetadata/Modinfo.cs
+++ b/ModManager_Classes/Models/ModMetadata/Modinfo.cs
@@ -9,6 +9,7 @@ namespace Imya.Models.ModMetadata
         public string? Version { get; set; }
         public string? ModID { get; set; }
         public string[]? IncompatibleIds { get; set; }
+        public string[]? DeprecateIds { get; set; }
         public string[]? ModDependencies { get; set; }
         public Localized? Category { get; set; }
         public Localized? ModName { get; set; }
@@ -32,6 +33,7 @@ namespace Imya.Models.ModMetadata
             Version = modinfo?.Version;
             ModID = modinfo?.ModID;
             IncompatibleIds = modinfo?.IncompatibleIds;
+            DeprecateIds = modinfo?.DeprecateIds;
             ModDependencies = modinfo?.ModDependencies;
             DLCDependencies = modinfo?.DLCDependencies;
             CreatorName = modinfo?.CreatorName;


### PR DESCRIPTION
Duplicate IDs were only marked obsolete after install.
This change marks them also on load / change as part of the validators.
Closes #155 

I also introduced a `DeprecateIds` to allow mod merges, as in one mod replaces two mods - one with same id and the other marked as deprecated for example.

A future improvement can be better tooltip about who deprecated what.