### PR TITLE
support skip/include toggle

### DIFF
--- a/ModManager_Classes/Models/ModTweaker/ExposedModValue.cs
+++ b/ModManager_Classes/Models/ModTweaker/ExposedModValue.cs
@@ -37,7 +37,7 @@ namespace Imya.Models.ModTweaker
         public bool IsEnumType { get => ExposedModValueType == ExposedModValueType.Enum; }
         public bool IsSimpleValue { get => ExposedModValueType == ExposedModValueType.SimpleValue; }
         public bool IsSliderType { get => ExposedModValueType == ExposedModValueType.Slider; }
-        public bool IsToggleType { get => ExposedModValueType == ExposedModValueType.Toggle; }
+        public bool IsToggleType { get => ExposedModValueType == ExposedModValueType.Toggle || ExposedModValueType == ExposedModValueType.SkipToggle; }
        
     }
 

--- a/ModManager_Classes/Models/ModTweaker/ExposedModValueFactory.cs
+++ b/ModManager_Classes/Models/ModTweaker/ExposedModValueFactory.cs
@@ -99,6 +99,23 @@ namespace Imya.Models.ModTweaker
                         return val; 
                     }
                 }
+                else if (type == ExposedModValueType.SkipToggle)
+                {
+                    var val = new ExposedToggleModValue()
+                    {
+                        Path = Path!,
+                        ModOpID = ModOpID!,
+                        ExposeID = ExposeID!,
+                        Parent = parent,
+                        Description = description,
+                        Tooltip = tooltip,
+                        FalseValue = "1",
+                        TrueValue = "0",
+                        IsInverted = false,
+                        ExposedModValueType = ExposedModValueType.SkipToggle
+                    };
+                    return val;
+                }
                 return new ExposedModValue()
                 {
                     Path = Path!,

--- a/ModManager_Classes/Models/ModTweaker/ExposedToggleModValue.cs
+++ b/ModManager_Classes/Models/ModTweaker/ExposedToggleModValue.cs
@@ -9,8 +9,8 @@ namespace Imya.Models.ModTweaker
 {
     public class ExposedToggleModValue : ExposedModValue
     {
-        public String TrueValue { get; private set; }
-        public String FalseValue { get; init; }
+        public String TrueValue { get; set; }
+        public String FalseValue { get; set; }
 
         public bool IsTrue {
             get => _isTrue;

--- a/ModManager_Classes/Models/ModTweaker/IExposedModValue.cs
+++ b/ModManager_Classes/Models/ModTweaker/IExposedModValue.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Imya.Models.ModTweaker
 {
-    public enum ExposedModValueType { SimpleValue, Enum, Slider, Toggle }
+    public enum ExposedModValueType { SimpleValue, Enum, Slider, Toggle, SkipToggle }
 
     public enum ExposedModValueReplaceType { Text, Xml }
 

--- a/ModManager_Classes/Models/ModTweaker/ModOp.cs
+++ b/ModManager_Classes/Models/ModTweaker/ModOp.cs
@@ -12,6 +12,7 @@ namespace Imya.Models.ModTweaker
     {
         public String? ID;
         public IEnumerable<XmlNode> Code;
+        public string? Skip;
 
         //Mod Op related things
         public String Type;
@@ -23,7 +24,13 @@ namespace Imya.Models.ModTweaker
 
         public static ModOp? FromXmlNode(XmlNode ModOp)
         {
-            if (ModOp.TryGetAttribute(TweakerConstants.TYPE, out String? ModOpType))
+            string? type = null;
+            if (ModOp.Name.ToLower() == "include")
+                type = "include";
+            if (type is null && ModOp.TryGetAttribute(TweakerConstants.TYPE, out string? ModOpType))
+                type = ModOpType;
+
+            if (type is not null)
             {
                 ModOp.TryGetAttribute(TweakerConstants.GUID, out String? Guid);
                 ModOp.TryGetAttribute(TweakerConstants.PATH, out String? Path);
@@ -32,9 +39,10 @@ namespace Imya.Models.ModTweaker
                 {
                     ID = ID!,
                     Code = ModOp.ChildNodes.Cast<XmlNode>().ToList(),
-                    Type = ModOpType!,
+                    Type = type,
                     GUID = Guid,
-                    Path = Path
+                    Path = Path,
+                    Skip = ModOp.Attributes?["Skip"]?.Value
                 };
             }
             return null;

--- a/ModManager_Classes/Models/ModTweaker/XmlPatchParser.cs
+++ b/ModManager_Classes/Models/ModTweaker/XmlPatchParser.cs
@@ -57,13 +57,16 @@ namespace Imya.Models.ModTweaker
 
         internal IEnumerable<ModOp> FetchModOps(XmlDocument ImportDocument)
         { 
-            var ModOps = Document.SelectNodes("/ModOps/ModOp");
+            var modOps = Document.SelectNodes("/ModOps/ModOp | /ModOps/Include");
+            if (modOps is null)
+                yield break;
 
-            foreach (XmlNode _ModOp in ModOps)
+            foreach (XmlNode modOp in modOps)
             {
-                var Imported = ImportDocument.ImportNode(_ModOp, true);
-                ModOp? op = ModOp.FromXmlNode(Imported);
-                if (op is not null && op.HasID) yield return op;
+                var imported = ImportDocument.ImportNode(modOp, true);
+                ModOp? op = ModOp.FromXmlNode(imported);
+                if (op is not null && op.HasID)
+                    yield return op;
             }
         }
 

--- a/ModManager_Classes/Utils/FrameworkExtensions.cs
+++ b/ModManager_Classes/Utils/FrameworkExtensions.cs
@@ -162,7 +162,7 @@ namespace Imya.Utils
 
         public static bool TryGetModOpNodes(this XmlDocument Document, String ModOpId, out XmlNodeList? ModOps)
         {
-            ModOps = Document.SelectNodes($@"/ModOps/ModOp[@{TweakerConstants.MODOP_ID} = '{ModOpId}']");
+            ModOps = Document.SelectNodes($@"/ModOps/*[(name()='ModOp' or name()='Include') and @{TweakerConstants.MODOP_ID} = '{ModOpId}']");
             return ModOps is not null && ModOps.Count > 0;
         }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12190313/202842740-80af0c1e-98ba-458a-8685-8494318acb6f.png)

```xml
  <Include Skip="0" File="./data/jakob/soap/assets.include.xml" ModOpID="Soap" />

  <!-- Alternative Needs: all applicable productions -->
  <Include Skip="0" File="./data/jakob/alternative-needs/assets.include.xml" ModOpID="AlternativeNeeds" />

  <!-- Toggle features via iModYourAnno -->
  <ImyaTweaks Title="Features" />
  <ImyaExpose Path="self" ModOpID="AlternativeNeeds" Kind="SkipToggle" ExposeID="Alternative Needs"
    Description="Vanilla population can consume Pescatarian goods as alternatives via Lifestyle." />
  <ImyaExpose Path="self" ModOpID="Soap" Kind="SkipToggle" ExposeID="Olive Soap"
    Description="Olive Soap is only used by Pescatarians and Alternative Needs." />
```

Skips don't work yet for includes in the modloader.
So, there are two options now:
1. add support to modloader (duh)
2. replace `<Include Skip=1 ...` with `<Disabled ...` instead. Renaming an XML node itself is a bit of pain though. 