### PR TITLE
show obsolete reason

### DIFF
--- a/ModManager/ValueConverters/AttributeConverters.cs
+++ b/ModManager/ValueConverters/AttributeConverters.cs
@@ -17,6 +17,7 @@ namespace Imya.UI.ValueConverters
                 AttributeType.ModStatus when status == ModStatus.New => ("Download", FindResourceBrush("HighlightColorBrush")),
                 AttributeType.ModStatus when status == ModStatus.Obsolete => ("RemoveCircleOutline", FindResourceBrush("ErrorColorBrush")),
                 AttributeType.ModCompabilityIssue => ("AlertBox", FindResourceBrush("ErrorColorBrush")),
+                AttributeType.ModReplacedByIssue => ("RemoveCircleOutline", FindResourceBrush("ErrorColorBrush")),
                 AttributeType.UnresolvedDependencyIssue => ("FileTree", FindResourceBrush("ErrorColorBrush")),
                 AttributeType.TweakedMod => ("Tools", FindResourceBrush("InformationColorBrush")),
                 AttributeType.MissingModinfo => ("HelpBox", FindResourceBrush("InformationColorBrush")),

--- a/ModManager/resources/texts.json
+++ b/ModManager/resources/texts.json
@@ -1248,6 +1248,19 @@
     "Spanish": null,
     "Taiwanese": null
   },
+  "ATTRIBUTE_REPLACEDBY": {
+    "Chinese": null,
+    "English": "This mod is old.\nIt has been replaced by '{0}'.",
+    "French": null,
+    "German": "Diese Mod ist alt.\nSie wurde durch '{0}' ersetzt.",
+    "Italian": null,
+    "Japanese": null,
+    "Korean": null,
+    "Polish": null,
+    "Russian": null,
+    "Spanish": null,
+    "Taiwanese": null
+  },
   "ATTRIBUTE_STATUS_OBSOLETE": {
     "Chinese": null,
     "English": "Obsolete",

--- a/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModReplacedByIssueAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/ConcreteAttributes/ModReplacedByIssueAttribute.cs
@@ -1,0 +1,19 @@
+﻿using Imya.Utils;
+
+namespace Imya.Models.Attributes
+{
+    public class ModReplacedByIssue : IAttribute
+    {
+        public AttributeType AttributeType { get; } = AttributeType.ModReplacedByIssue;
+        public IText Description { get => new SimpleText(string.Format(TextManager.Instance.GetText("ATTRIBUTE_REPLACEDBY").Text, _replacedBy.FolderName)); }
+
+        bool IAttribute.MultipleAllowed => true;
+
+        readonly Mod _replacedBy; 
+
+        public ModReplacedByIssue(Mod replacedBy)
+        {
+            _replacedBy = replacedBy;
+        }
+    }
+}

--- a/ModManager_Classes/Models/Attributes/IAttribute.cs
+++ b/ModManager_Classes/Models/Attributes/IAttribute.cs
@@ -15,7 +15,8 @@ namespace Imya.Models.Attributes
         MissingModinfo,
         ModContentInSubfolder,
         IssueModRemoved,
-        IssueModAccess
+        IssueModAccess,
+        ModReplacedByIssue
     }
 
     public interface IAttribute

--- a/ModManager_Classes/Models/ModTweaker/TweakerFile.cs
+++ b/ModManager_Classes/Models/ModTweaker/TweakerFile.cs
@@ -183,7 +183,7 @@ namespace Imya.Models.ModTweaker
             attrib.Value = Filepath;
             n.Attributes!.Append(attrib);
 
-            OriginalDocument.FirstChild?.AppendChild(n);
+            OriginalDocument.SelectSingleNode("/ModOps")?.AppendChild(n);
         }
 
         /// <summary>


### PR DESCRIPTION
An error for obsolete or duplicate mods should tell the user which mod is the new one.