### PR TITLE
Add Ratelimiting

### DIFF
--- a/ModManager/Properties/Settings.Designer.cs
+++ b/ModManager/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Imya.UI.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.0.3.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -176,6 +176,30 @@ namespace Imya.UI.Properties {
             }
             set {
                 this["ModloaderEnabled"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1048576")]
+        public long DownloadRateLimit {
+            get {
+                return ((long)(this["DownloadRateLimit"]));
+            }
+            set {
+                this["DownloadRateLimit"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool UseRatelimit {
+            get {
+                return ((bool)(this["UseRatelimit"]));
+            }
+            set {
+                this["UseRatelimit"] = value;
             }
         }
     }

--- a/ModManager/Properties/Settings.settings
+++ b/ModManager/Properties/Settings.settings
@@ -41,5 +41,11 @@
     <Setting Name="ModloaderEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="DownloadRateLimit" Type="System.Int64" Scope="User">
+      <Value Profile="(Default)">1048576</Value>
+    </Setting>
+    <Setting Name="UseRatelimit" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ModManager/Styles/SliderStyle.xaml
+++ b/ModManager/Styles/SliderStyle.xaml
@@ -23,7 +23,7 @@
                                         Foreground="{DynamicResource TextColorBrush}"
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
-                                        Margin="0,-2"/>
+                                        Margin="2,1"/>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
@@ -81,8 +81,8 @@
                     <Components:ContentThumb Style="{StaticResource IMYA_SLIDERTHUMB}"
                                              Foreground="{TemplateBinding Foreground}"
                                              Background="{DynamicResource InteractiveComponentColorBrush}"
-                                             Width="22"
-                                             Height="18"
+                                             Width="Auto"
+                                             Height="Auto"
                                              Content="{TemplateBinding Content}">
                     </Components:ContentThumb>
                     

--- a/ModManager/Utils/AppSettings.cs
+++ b/ModManager/Utils/AppSettings.cs
@@ -161,16 +161,33 @@ namespace Imya.UI.Utils
         }
         private ThemeSetting _theme;
 
-        public int DownloadRateLimit
+        public long DownloadRateLimit
         {
-            get => _downloadRateLimit;
+            get => Properties.Settings.Default.DownloadRateLimit;
             set
             {
-                InstallationManager.Instance.DownloadConfig.MaximumBytesPerSecond = value;
-                SetProperty(ref _downloadRateLimit, value);
+                Properties.Settings.Default.DownloadRateLimit = value;
+                Properties.Settings.Default.Save();
+                RateLimitChanged(UseRateLimiting ? value : 0);
+                OnPropertyChanged(nameof(UseRateLimiting));
             }
         }
-        private int _downloadRateLimit;
+
+        public bool UseRateLimiting
+        {
+            get => Properties.Settings.Default.UseRatelimit;
+            set 
+            {
+                Properties.Settings.Default.UseRatelimit = value; 
+                Properties.Settings.Default.Save();
+                RateLimitChanged(value ? DownloadRateLimit : 0);
+                OnPropertyChanged(nameof(UseRateLimiting));
+            }
+        }
+
+        public delegate void RateLimitChangedEventHandler(long new_rate_limit);
+        public event RateLimitChangedEventHandler RateLimitChanged = delegate { };
+
         public AppSettings()
         {
             Themes.Add(new ThemeSetting(TextManager["THEME_GREEN"], "Styles/Themes/DarkGreen.xaml", "DarkGreen", Colors.DarkOliveGreen));
@@ -179,6 +196,8 @@ namespace Imya.UI.Utils
 
             Languages.Add(new LanguageSetting("SETTINGS_LANG_ENGLISH", ApplicationLanguage.English));
             Languages.Add(new LanguageSetting("SETTINGS_LANG_GERMAN", ApplicationLanguage.German));
+
+            RateLimitChanged += x => InstallationManager.Instance.DownloadConfig.MaximumBytesPerSecond = x;
 
             Instance ??= this;
         }

--- a/ModManager/Utils/AppSettings.cs
+++ b/ModManager/Utils/AppSettings.cs
@@ -169,7 +169,7 @@ namespace Imya.UI.Utils
                 Properties.Settings.Default.DownloadRateLimit = value;
                 Properties.Settings.Default.Save();
                 RateLimitChanged(UseRateLimiting ? value : 0);
-                OnPropertyChanged(nameof(UseRateLimiting));
+                OnPropertyChanged(nameof(DownloadRateLimit));
             }
         }
 

--- a/ModManager/Utils/AppSettings.cs
+++ b/ModManager/Utils/AppSettings.cs
@@ -161,6 +161,16 @@ namespace Imya.UI.Utils
         }
         private ThemeSetting _theme;
 
+        public int DownloadRateLimit
+        {
+            get => _downloadRateLimit;
+            set
+            {
+                InstallationManager.Instance.DownloadConfig.MaximumBytesPerSecond = value;
+                SetProperty(ref _downloadRateLimit, value);
+            }
+        }
+        private int _downloadRateLimit;
         public AppSettings()
         {
             Themes.Add(new ThemeSetting(TextManager["THEME_GREEN"], "Styles/Themes/DarkGreen.xaml", "DarkGreen", Colors.DarkOliveGreen));

--- a/ModManager/ValueConverters/SizeConverters.cs
+++ b/ModManager/ValueConverters/SizeConverters.cs
@@ -14,9 +14,11 @@ namespace Imya.UI.ValueConverters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is not double dvalue)
-                return String.Empty;
-            return Math.Round(dvalue / (1024 * 1024), 2) + " MB/s";
+            if (value is double dvalue)
+                return Math.Round(dvalue / (1024 * 1024), 2) + " MB/s";
+            if (value is long lvalue)
+                return Math.Round((float)lvalue / (1024 * 1024), 2) + " MB/s";
+            return String.Empty;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -30,9 +32,11 @@ namespace Imya.UI.ValueConverters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is not long lvalue)
-                return String.Empty;
-            return Math.Round(lvalue / (float)(1024 * 1024), 2) + " MB";
+            if (value is double dvalue)
+                return Math.Round(dvalue / (1024 * 1024), 2) + " MB";
+            if (value is long lvalue)
+                return Math.Round((float)lvalue / (1024 * 1024), 2) + " MB";
+            return String.Empty;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/ModManager/Views/InstallationView.xaml
+++ b/ModManager/Views/InstallationView.xaml
@@ -47,7 +47,7 @@
                                           DownloadService="{Binding InstallationManager.DownloadService, UpdateSourceTrigger=PropertyChanged}"/>
         </Border> -->
         <TextBlock Text="{Binding CurrentDownloadSpeedPerSecond, Converter={StaticResource DownloadSpeed}}" 
-                   />
+                   Visibility="{Binding Settings.DevMode, Converter={StaticResource VisibleOnTrue}}"/>
 
         <!-- INSTALLS -->
         <ScrollViewer

--- a/ModManager/Views/InstallationView.xaml
+++ b/ModManager/Views/InstallationView.xaml
@@ -46,7 +46,8 @@
                                           CurrentValue="{Binding CurrentDownloadSpeedPerSecond, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource DownloadSpeed}}"
                                           DownloadService="{Binding InstallationManager.DownloadService, UpdateSourceTrigger=PropertyChanged}"/>
         </Border> -->
-        <TextBlock Text="{Binding CurrentDownloadSpeedPerSecond}" />
+        <TextBlock Text="{Binding CurrentDownloadSpeedPerSecond, Converter={StaticResource DownloadSpeed}}" 
+                   />
 
         <!-- INSTALLS -->
         <ScrollViewer

--- a/ModManager/Views/InstallationView.xaml
+++ b/ModManager/Views/InstallationView.xaml
@@ -46,7 +46,7 @@
                                           CurrentValue="{Binding CurrentDownloadSpeedPerSecond, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource DownloadSpeed}}"
                                           DownloadService="{Binding InstallationManager.DownloadService, UpdateSourceTrigger=PropertyChanged}"/>
         </Border> -->
-
+        <TextBlock Text="{Binding CurrentDownloadSpeedPerSecond}" />
 
         <!-- INSTALLS -->
         <ScrollViewer

--- a/ModManager/Views/InstallationView.xaml.cs
+++ b/ModManager/Views/InstallationView.xaml.cs
@@ -33,7 +33,7 @@ namespace Imya.UI.Views
         public TextManager TextManager { get; } = TextManager.Instance;
         public GameSetupManager GameSetup { get; } = GameSetupManager.Instance;
 
-        public Properties.Settings Settings { get; } = Properties.Settings.Default;
+        public AppSettings Settings { get; } = AppSettings.Instance;
 
         public InstallationManager InstallationManager { get; } = InstallationManager.Instance;
 

--- a/ModManager/Views/SettingsView.xaml
+++ b/ModManager/Views/SettingsView.xaml
@@ -192,8 +192,12 @@
                         </Grid.ColumnDefinitions>
                         <TextBox Style="{StaticResource IMYA_TEXTBOX}"
                                  Text="{Binding AppSettings.DownloadRateLimit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                            
                         </TextBox>
+                        <controls:FancyToggle Grid.Column="1"
+                                              Margin="5"
+                                              IsChecked="{Binding AppSettings.UseRateLimiting, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                            
+                        </controls:FancyToggle>
                     </Grid>
                     <Grid Visibility="{Binding AppSettings.DevMode, Converter={StaticResource VisibleOnTrue}, UpdateSourceTrigger=PropertyChanged}">
                         <Grid.ColumnDefinitions>

--- a/ModManager/Views/SettingsView.xaml
+++ b/ModManager/Views/SettingsView.xaml
@@ -6,6 +6,7 @@
              xmlns:controls="clr-namespace:Imya.UI.Controls"
              xmlns:converters="clr-namespace:Imya.UI.ValueConverters"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:Components="clr-namespace:Imya.UI.Views.Components"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
@@ -20,6 +21,8 @@
 
         <Grid.Resources>
             <BooleanToVisibilityConverter x:Key="BoolToVis" />
+            <converters:SpeedConverter x:Key="DownloadSpeed" />
+            <converters:ByteSizeConverter x:Key="Bytesize" />
             <converters:ExtendedBoolToVisibilityConverter x:Key="VisibleOnTrue" TrueValue="Visible" FalseValue="Collapsed" />
         </Grid.Resources>
 
@@ -188,16 +191,43 @@
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />
-                            <ColumnDefinition Width="200" />                            
+                            <ColumnDefinition Width="2*" />
                         </Grid.ColumnDefinitions>
-                        <TextBox Style="{StaticResource IMYA_TEXTBOX}"
-                                 Text="{Binding AppSettings.DownloadRateLimit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                        </TextBox>
+                        <TextBlock Style="{StaticResource IMYA_TEXT}"
+                                   Margin="5"
+                                   VerticalAlignment="Center"
+                                   Text="Download Rate"></TextBlock>
                         <controls:FancyToggle Grid.Column="1"
                                               Margin="5"
+                                              OffText="Unlimited"
+                                              OnText="limited to"
                                               IsChecked="{Binding AppSettings.UseRateLimiting, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                             
                         </controls:FancyToggle>
+                    </Grid>
+                    <Grid Margin="5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition />
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{Binding Min, Converter={StaticResource Bytesize}}"
+                                   Style="{StaticResource IMYA_TEXT}" />
+                        <Components:ContentSlider Grid.Column="1"
+                                                  Style="{StaticResource IMYA_SLIDER}"
+                                                  Value="{Binding AppSettings.DownloadRateLimit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                  Content="{Binding AppSettings.DownloadRateLimit, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource DownloadSpeed}}"
+                                                  Foreground="{DynamicResource AccentColorBrush}"
+                                                  Minimum="{Binding Min}"
+                                                  Maximum="{Binding Max}"
+                                                  TickFrequency="{Binding Stepping}"
+                                                  IsSnapToTickEnabled="True"
+                                                  Background="{DynamicResource InteractiveComponentColorBrush_Light}">
+                            
+                        </Components:ContentSlider>
+                        <TextBlock Text="{Binding Max, Converter={StaticResource Bytesize}}"
+                                   Style="{StaticResource IMYA_TEXT}" 
+                                   />
                     </Grid>
                     <Grid Visibility="{Binding AppSettings.DevMode, Converter={StaticResource VisibleOnTrue}, UpdateSourceTrigger=PropertyChanged}">
                         <Grid.ColumnDefinitions>

--- a/ModManager/Views/SettingsView.xaml
+++ b/ModManager/Views/SettingsView.xaml
@@ -22,7 +22,6 @@
         <Grid.Resources>
             <BooleanToVisibilityConverter x:Key="BoolToVis" />
             <converters:SpeedConverter x:Key="DownloadSpeed" />
-            <converters:ByteSizeConverter x:Key="Bytesize" />
             <converters:ExtendedBoolToVisibilityConverter x:Key="VisibleOnTrue" TrueValue="Visible" FalseValue="Collapsed" />
         </Grid.Resources>
 
@@ -205,14 +204,15 @@
                             
                         </controls:FancyToggle>
                     </Grid>
-                    <Grid Margin="5">
+                    <Grid Margin="5" Visibility="{Binding AppSettings.UseRateLimiting, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource VisibleOnTrue}}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition />
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Text="{Binding Min, Converter={StaticResource Bytesize}}"
-                                   Style="{StaticResource IMYA_TEXT}" />
+                        <TextBlock Text="{Binding Min, Converter={StaticResource DownloadSpeed}}"
+                                   Style="{StaticResource IMYA_TEXT}"
+                                   Margin="4,2" />
                         <Components:ContentSlider Grid.Column="1"
                                                   Style="{StaticResource IMYA_SLIDER}"
                                                   Value="{Binding AppSettings.DownloadRateLimit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -222,11 +222,14 @@
                                                   Maximum="{Binding Max}"
                                                   TickFrequency="{Binding Stepping}"
                                                   IsSnapToTickEnabled="True"
+                                                  Margin="5,0"
                                                   Background="{DynamicResource InteractiveComponentColorBrush_Light}">
                             
                         </Components:ContentSlider>
-                        <TextBlock Text="{Binding Max, Converter={StaticResource Bytesize}}"
+                        <TextBlock Text="{Binding Max, Converter={StaticResource DownloadSpeed}}"
                                    Style="{StaticResource IMYA_TEXT}" 
+                                   Grid.Column="2"
+                                   Margin="4,2"
                                    />
                     </Grid>
                     <Grid Visibility="{Binding AppSettings.DevMode, Converter={StaticResource VisibleOnTrue}, UpdateSourceTrigger=PropertyChanged}">

--- a/ModManager/Views/SettingsView.xaml
+++ b/ModManager/Views/SettingsView.xaml
@@ -185,6 +185,16 @@
                                               IsChecked="{Binding AppSettings.InstallationOptions.AllowOldToOverwrite, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         </controls:FancyToggle>
                     </Grid>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition Width="200" />                            
+                        </Grid.ColumnDefinitions>
+                        <TextBox Style="{StaticResource IMYA_TEXTBOX}"
+                                 Text="{Binding AppSettings.DownloadRateLimit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                            
+                        </TextBox>
+                    </Grid>
                     <Grid Visibility="{Binding AppSettings.DevMode, Converter={StaticResource VisibleOnTrue}, UpdateSourceTrigger=PropertyChanged}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />

--- a/ModManager/Views/SettingsView.xaml
+++ b/ModManager/Views/SettingsView.xaml
@@ -158,7 +158,7 @@
                     Margin="0,12,0,6"
                     MinHeight="30">
                 <TextBlock Style="{StaticResource IMYA_TEXT}"
-                           Text="Installation and Download"
+                           Text="{Binding TextManager[SETTINGS_INST_DL_SECTION].Text}"
                            FontWeight="Bold"
                            HorizontalAlignment="Center"
                            VerticalAlignment="Center"></TextBlock>
@@ -195,11 +195,11 @@
                         <TextBlock Style="{StaticResource IMYA_TEXT}"
                                    Margin="5"
                                    VerticalAlignment="Center"
-                                   Text="Download Rate"></TextBlock>
+                                   Text="{Binding TextManager[SETTINGS_DL_RATE].Text}"></TextBlock>
                         <controls:FancyToggle Grid.Column="1"
                                               Margin="5"
-                                              OffText="Unlimited"
-                                              OnText="limited to"
+                                              OffText="{Binding TextManager[SETTINGS_DL_RATE_UNLIMITED].Text}"
+                                              OnText="{Binding TextManager[SETTINGS_DL_RATE_LIMITED].Text}"
                                               IsChecked="{Binding AppSettings.UseRateLimiting, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                             
                         </controls:FancyToggle>

--- a/ModManager/Views/SettingsView.xaml.cs
+++ b/ModManager/Views/SettingsView.xaml.cs
@@ -23,6 +23,10 @@ namespace Imya.UI.Views
 
         public AppSettings AppSettings { get; set; } = AppSettings.Instance;
 
+        public long Max { get; } = 100 * 1024 * 1024;
+        public long Min { get; } = 256 * 1024;
+        public long Stepping { get; } = 256 * 1024;
+
         #region Notifiable Properties
         public event PropertyChangedEventHandler? PropertyChanged = delegate { };
         protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new(propertyName));

--- a/ModManager/resources/texts.json
+++ b/ModManager/resources/texts.json
@@ -1664,6 +1664,58 @@
     "Spanish": null,
     "Taiwanese": null
   },
+  "SETTINGS_INST_DL_SECTION": {
+    "Chinese": null,
+    "English": "Installation and Download",
+    "French": null,
+    "German": "Installationen und Downloads",
+    "Italian": null,
+    "Japanese": null,
+    "Korean": null,
+    "Polish": null,
+    "Russian": null,
+    "Spanish": null,
+    "Taiwanese": null
+  },
+  "SETTINGS_DL_RATE_UNLIMITED": {
+    "Chinese": null,
+    "English": "Unlimited",
+    "French": null,
+    "German": "Unbegrenzt",
+    "Italian": null,
+    "Japanese": null,
+    "Korean": null,
+    "Polish": null,
+    "Russian": null,
+    "Spanish": null,
+    "Taiwanese": null
+  },
+  "SETTINGS_DL_RATE_LIMITED": {
+    "Chinese": null,
+    "English": "Limited",
+    "French": null,
+    "German": "Gedrosselt",
+    "Italian": null,
+    "Japanese": null,
+    "Korean": null,
+    "Polish": null,
+    "Russian": null,
+    "Spanish": null,
+    "Taiwanese": null
+  },
+  "SETTINGS_DL_RATE": {
+    "Chinese": null,
+    "English": "Download Speed",
+    "French": null,
+    "German": "Download-Geschwindigkeit",
+    "Italian": null,
+    "Japanese": null,
+    "Korean": null,
+    "Polish": null,
+    "Russian": null,
+    "Spanish": null,
+    "Taiwanese": null
+  },
   "CONTROLS_TOGGLE_HIDE": {
     "Chinese": null,
     "English": "hide",

--- a/ModManager_Classes/Utils/InstallationManager.cs
+++ b/ModManager_Classes/Utils/InstallationManager.cs
@@ -26,6 +26,8 @@ namespace Imya.Utils
         public ObservableCollection<IInstallation> ActiveInstallations { get; private set; }
         public List<String> CurrentGithubInstallsIDs { get; private set; }
 
+        public DownloadConfiguration DownloadConfig { get; private set; }
+
         public DownloadService DownloadService {
             get => _downloadService;
             set => SetProperty(ref _downloadService, value);
@@ -108,8 +110,14 @@ namespace Imya.Utils
             ActiveInstallations = new();
             CurrentGithubInstallsIDs = new();
 
+            DownloadConfig = new DownloadConfiguration()
+            {
+                //rate limited to 1MB/s
+                MaximumBytesPerSecond = 1024 * 1024
+            };
+
             //TODO add options
-            DownloadService = new();
+            DownloadService = new(DownloadConfig);
             DownloadService.DownloadProgressChanged += OnDownloadProgressChanged; 
 
             //when an install gets added, we invoke process with next download, semaphore does the rest for us. 


### PR DESCRIPTION
Adds an option to ratelimit downloads. Here is the UI on the user side:

![image](https://user-images.githubusercontent.com/51975164/211941390-c6311c9d-ab8d-4193-82eb-ef40bd74c4ea.png)

When turning rate limiting off, the slider disappears. 

This ticks another box in #169 