### PR TITLE
Devel/fix onoff performance

### DIFF
--- a/ModManager/Models/BindableModCollection.cs
+++ b/ModManager/Models/BindableModCollection.cs
@@ -16,9 +16,12 @@ namespace Imya.UI.Models
         public int ActiveSizeInMBs => Model.ActiveSizeInMBs;
         public int InstalledSizeInMBs => Model.InstalledSizeInMBs;
 
+        public ModCollection WrappedCollection; 
+
         public BindableModCollection(ModCollection collection, DispatcherObject context) : base(collection, context, (x, c) => new BindableMod(x, c))
         {
             Order = CompareByActiveCategoryName.Default;
+            WrappedCollection = collection;
         }
     }
 }

--- a/ModManager/Views/Components/ModList.xaml.cs
+++ b/ModManager/Views/Components/ModList.xaml.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows.Controls;
 
 namespace Imya.UI.Components
@@ -60,15 +61,17 @@ namespace Imya.UI.Components
 
         public async void ActivateSelection()
         {
-            foreach (Mod mod in ListBox_ModList.SelectedItems.OfType<BindableMod>().Select(x => x.Model).ToArray())
-                await mod.ChangeActivationAsync(true);
+            var selected = ListBox_ModList.SelectedItems.OfType<BindableMod>().Select(x => x.Model).ToArray();
+            await Mods.WrappedCollection.ChangeActivationAsync(selected, true);
+
             OnSelectionChanged(); 
         }
 
         public async void DeactivateSelection()
         {
-            foreach (Mod mod in ListBox_ModList.SelectedItems.OfType<BindableMod>().Select(x => x.Model).ToArray())
-                await mod.ChangeActivationAsync(false);
+            var selected = ListBox_ModList.SelectedItems.OfType<BindableMod>().Select(x => x.Model).ToArray();
+            await Mods.WrappedCollection.ChangeActivationAsync(selected, false);
+
             OnSelectionChanged();
         }
 

--- a/ModManager/Views/Components/ModList.xaml.cs
+++ b/ModManager/Views/Components/ModList.xaml.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using System.Windows.Controls;
 
 namespace Imya.UI.Components

--- a/tests/Imya.UnitTests/ExternalAccessTests.cs
+++ b/tests/Imya.UnitTests/ExternalAccessTests.cs
@@ -29,7 +29,7 @@ namespace Imya.UnitTests
             DirectoryEx.EnsureDeleted(folder);
 
             // deactivate deleted mod
-            await mods.Mods[0].ChangeActivationAsync(false);
+            await mods.ChangeActivationAsync(mods.Mods[0], false);
 
             // mod should be still in the list, but marked as removed
             Assert.Single(mods);
@@ -100,7 +100,7 @@ namespace Imya.UnitTests
             // check
             Assert.Single(mods);
             DirectoryEx.EnsureDeleted(folderA);
-            await mods.Mods[0].ChangeActivationAsync(false);
+            await mods.ChangeActivationAsync(mods.Mods[0], false);
             Assert.Single(mods);
             Assert.True(mods.Mods[0].IsRemoved);
 
@@ -131,7 +131,7 @@ namespace Imya.UnitTests
             // check
             Assert.Single(mods);
             DirectoryEx.EnsureDeleted(folderA);
-            await mods.Mods[0].ChangeActivationAsync(false);
+            await mods.ChangeActivationAsync(mods.Mods[0], false);
             Assert.Single(mods);
             Assert.True(mods.Mods[0].IsRemoved);
 


### PR DESCRIPTION
We were running the collection hooks for as many times as there are changed mods... anyway, this should not be the case anymore

- Moved Mod Activation/Deactivation to the mod collection. 
- Removed the ability to change activation of a mod outside of the collection, so we can forget about bubbling up events from single mod to collection. 

closes #178 