### PR TITLE
Cancelling Downloads

### DIFF
--- a/ModManager/Views/InstallationView.xaml
+++ b/ModManager/Views/InstallationView.xaml
@@ -130,7 +130,7 @@
                                                        FontWeight="Bold"
                                                        TextAlignment="Right"
                                                        Style="{StaticResource IMYA_TEXT}"
-                                                       Text="{Binding CurrentDownloadSpeedPerSecond, Converter={StaticResource DownloadSpeed}}"
+                                                       Text="{Binding InstallationManager.BytesPerSecondSpeed, Converter={StaticResource DownloadSpeed}}"
                                                        DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:InstallationView}}}" />
                                         </Grid>
                                         
@@ -155,7 +155,9 @@
                                                 Margin="5,0"
                                                 MinHeight="38"
                                                 MinWidth="38"
-                                                HorizontalContentAlignment="Center">
+                                                Click="CancelButtonClicked"
+                                                HorizontalContentAlignment="Center"
+                                                IsEnabled="{Binding CanBePaused,UpdateSourceTrigger=PropertyChanged}">
                                             <materialDesign:PackIcon Kind="Cancel"
                                                                      Style="{StaticResource IMYA_ICON}">
 
@@ -271,7 +273,8 @@
                                                 Style="{StaticResource IMYA_BUTTON}"
                                                 HorizontalContentAlignment="Center"
                                                 Height="38"
-                                                Width="38">
+                                                Width="38"
+                                                Click="RemoveButtonClicked">
                                             <materialDesign:PackIcon Kind="TrashCanOutline"
                                                                      Style="{StaticResource IMYA_ICON}" />
                                         </Button>

--- a/ModManager/Views/InstallationView.xaml.cs
+++ b/ModManager/Views/InstallationView.xaml.cs
@@ -53,12 +53,6 @@ namespace Imya.UI.Views
         private ModLoaderStatus _installStatus = ModLoaderStatus.NotInstalled;
 
 
-        public double CurrentDownloadSpeedPerSecond
-        {
-            get => _currentDownloadSpeedPerSecond;
-            set => SetProperty(ref _currentDownloadSpeedPerSecond, value);
-        }
-        private double _currentDownloadSpeedPerSecond;
 
         #endregion
 
@@ -74,18 +68,7 @@ namespace Imya.UI.Views
             if (GameSetup.IsModloaderInstalled)
             {
                 InstallStatus = ModLoaderStatus.Installed;
-            }
-
-            InstallationManager.DownloadService.DownloadProgressChanged += OnDownloadProgressChanged;
-            //InstallationManager.DownloadService.DownloadProgressChanged += DownloadInfoDisplay.OnDownloadProgressChanged;
-        }
-
-        private void OnDownloadProgressChanged(object? sender, DownloadProgressChangedEventArgs e)
-        {
-            if (sender is not DownloadService dl_service || dl_service.IsPaused)
-                return;
-
-            CurrentDownloadSpeedPerSecond = e.BytesPerSecondSpeed;
+            }            
         }
 
         public async void OnInstallModLoader(object sender, RoutedEventArgs e)
@@ -121,8 +104,27 @@ namespace Imya.UI.Views
             else
             {
                 InstallationManager.Pause();
-                CurrentDownloadSpeedPerSecond = 0;
             }           
+        }
+
+        private async void CancelButtonClicked(object sender, RoutedEventArgs e)
+        {
+            var but = sender as Button;
+            var installation = but?.DataContext as IInstallation;
+            if (installation is null)
+                return;
+
+            await InstallationManager.CancelAsync(installation);
+        }
+
+        private void RemoveButtonClicked(object sender, RoutedEventArgs e)
+        {
+            var but = sender as Button;
+            var installation = but?.DataContext as IDownloadableUnpackableInstallation;
+            if (installation is null)
+                return;
+
+            InstallationManager.RemovePending(installation);
         }
     }
 

--- a/ModManager_Classes/ModManager_Classes.csproj
+++ b/ModManager_Classes/ModManager_Classes.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Downloader" Version="3.0.2" />
+    <PackageReference Include="Downloader" Version="3.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/ModManager_Classes/Models/Collections/IQueue.cs
+++ b/ModManager_Classes/Models/Collections/IQueue.cs
@@ -12,6 +12,8 @@ namespace Imya.Models.Collections
         T Dequeue();
         void Enqueue(T item);
 
+        void Remove(T item);
+
         int Count();        
     }
 }

--- a/ModManager_Classes/Models/Collections/WrappedQueue.cs
+++ b/ModManager_Classes/Models/Collections/WrappedQueue.cs
@@ -9,35 +9,44 @@ namespace Imya.Models.Collections
     //A simple wrapper to have a default queue that implements our IQueue interface
     public class WrappedQueue<T> : IQueue<T>
     {
-        private Queue<T> _queue;
+        private List<T> _list;
 
         public event NotifyCollectionChangedEventHandler? CollectionChanged;
 
         public WrappedQueue()
         {
-            _queue = new Queue<T>();
+            _list = new List<T>();
         }
 
         public void Enqueue(T item)
         {
-            _queue.Enqueue(item);
+            _list.Add(item);
             CollectionChanged?.Invoke(this, 
                 new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
         }
 
         public T Dequeue() 
         {
-            var item = _queue.Dequeue();
+            var item = _list.First();
+            _list.RemoveAt(0);
             CollectionChanged?.Invoke(this,
                 new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, 0));
             return item;
         }
 
+        public void Remove(T item)
+        {
+            var index = _list.IndexOf(item);
+            _list.Remove(item);
+            CollectionChanged?.Invoke(this,
+                new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
+        }
 
-        public int Count() => _queue.Count();
 
-        public IEnumerator<T> GetEnumerator() => _queue.GetEnumerator();
+        public int Count() => _list.Count();
 
-        IEnumerator IEnumerable.GetEnumerator() => _queue.GetEnumerator();
+        public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
     }
 }

--- a/ModManager_Classes/Models/Installation/GithubInstallationBuilder.cs
+++ b/ModManager_Classes/Models/Installation/GithubInstallationBuilder.cs
@@ -84,7 +84,8 @@ namespace Imya.Models.Installation
                 AdditionalText = new SimpleText(additional),
                 ID = id,
                 Status = InstallationStatus.NotStarted,
-                ImageUrl= url
+                ImageUrl = url,
+                CancellationTokenSource = new CancellationTokenSource()
             };    
             return _installation;
         }

--- a/ModManager_Classes/Models/Installation/IInstallation.cs
+++ b/ModManager_Classes/Models/Installation/IInstallation.cs
@@ -17,7 +17,12 @@ namespace Imya.Models.Installation
         IText? AdditionalText { get; }
         bool HasAdditionalText { get; }
         IInstallationStatus? Status { get; set; }
+
+        CancellationTokenSource CancellationTokenSource { get; }
+        CancellationToken CancellationToken { get; }
+
         void SetProgressRange(float Min, float Max);
+
     }
 
     public interface IInstallationStatus

--- a/ModManager_Classes/Models/Installation/Installation.cs
+++ b/ModManager_Classes/Models/Installation/Installation.cs
@@ -69,6 +69,10 @@ namespace Imya.Models.Installation
 
         public string? ImageUrl { get; init; }
 
+        public CancellationToken CancellationToken { get => CancellationTokenSource.Token; }
+
+        public CancellationTokenSource CancellationTokenSource { get; init; }
+
         public void Report(float value) => Progress = _progressRange.Item1 + value * (_progressRange.Item2 - _progressRange.Item1);
 
         public void SetProgressRange(float Min, float Max)

--- a/ModManager_Classes/Models/Installation/ZipInstallationBuilder.cs
+++ b/ModManager_Classes/Models/Installation/ZipInstallationBuilder.cs
@@ -37,7 +37,8 @@ namespace Imya.Models.Installation
                 SourceFilepath = _source,
                 UnpackTargetPath = Path.Combine(ImyaSetupManager.Instance.UnpackDirectoryPath, guid),
                 HeaderText = new SimpleText(header),
-                Status = InstallationStatus.NotStarted
+                Status = InstallationStatus.NotStarted,
+                CancellationTokenSource = new CancellationTokenSource()
             };
             return installation;
         }

--- a/ModManager_Classes/Models/ModCollection.cs
+++ b/ModManager_Classes/Models/ModCollection.cs
@@ -217,7 +217,7 @@ namespace Imya.Models
         /// Source collection folder will be deleted afterwards.
         /// Existing mods will be overwriten, old names with same mod id deactivated.
         /// </summary>
-        public async Task MoveIntoAsync(ModCollection source, bool allowOldToOverwrite = false)
+        public async Task MoveIntoAsync(ModCollection source, bool allowOldToOverwrite = false, CancellationToken ct = default)
         {
             Directory.CreateDirectory(ModsPath);
 
@@ -226,7 +226,8 @@ namespace Imya.Models
                 foreach (var sourceMod in source.Mods)
                 {
                     await Task.Run( 
-                        async () => await MoveSingleModIntoAsync(sourceMod, source.ModsPath, allowOldToOverwrite)
+                        async () => await MoveSingleModIntoAsync(sourceMod, source.ModsPath, allowOldToOverwrite),
+                        ct
                     );
                 }
             }


### PR DESCRIPTION
Approach:

- Give Downloads a Cancellation Token
- The installation methods only ever do shit when the token isn't cancelled
- If I want to cancel an installation, I just cancel the token and for the rest of the installation nothing happens. 

- Downloads in the pending queue are simply removed from the queue before ever being started. 

Unfortunatly I had to restart the DownloadService after every cancelled install, because it does dumb shit after being disposed. (everything except throwing a disposedexception)

closes #188 