### PR TITLE
Game Launch Fix

### DIFF
--- a/ModManager/ValueConverters/BooleanMultiAndConverter.cs
+++ b/ModManager/ValueConverters/BooleanMultiAndConverter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace Imya.UI.ValueConverters
+{
+    public class BooleanMultiAndConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            var bools = values.Where(x => x is bool).Select(x => (bool)x);
+            if (bools.Count() == 0)
+                return true;
+            return bools.Aggregate((x, y) => x && y);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/ModManager/Views/Components/Dashboard.xaml
+++ b/ModManager/Views/Components/Dashboard.xaml
@@ -20,6 +20,8 @@
         </Grid.RowDefinitions>
         <Grid.Resources>
             <BooleanToVisibilityConverter x:Key="BoolToVis" />
+            <Converters:BooleanMultiAndConverter x:Key="BoolMultiAnd" />
+            <Converters:NegateBoolConverter x:Key="NegateBool" />
             <Converters:ExtendedBoolToVisibilityConverter x:Key="NegateBoolToVis" TrueValue="Collapsed" FalseValue="Visible" />
         </Grid.Resources>
         <!-- Headline Dashboard -->
@@ -45,8 +47,17 @@
                     MinHeight="32"
                     Margin="5,4,4,0"
                     HorizontalContentAlignment="Left"
-                    IsEnabled="{Binding CanStartGame, UpdateSourceTrigger=PropertyChanged}"
                     Click="StartGameClick">
+                <Button.IsEnabled>
+                    <MultiBinding Converter="{StaticResource BoolMultiAnd}"
+                                  UpdateSourceTrigger="PropertyChanged">
+                        <Binding Path="GameSetupManager.IsValidSetup"
+                                 UpdateSourceTrigger="PropertyChanged" />
+                        <Binding Path="GameSetupManager.IsGameRunning"
+                                 Converter="{StaticResource NegateBool}"
+                                 UpdateSourceTrigger="PropertyChanged" />
+                    </MultiBinding>
+                </Button.IsEnabled>
                 <DockPanel Margin="10,0,0,0"
                            HorizontalAlignment="Left"
                            VerticalAlignment="Stretch">

--- a/ModManager/Views/Components/ModList.xaml.cs
+++ b/ModManager/Views/Components/ModList.xaml.cs
@@ -23,7 +23,6 @@ namespace Imya.UI.Components
         /// </summary>
         public Mod? CurrentlySelectedMod { get; private set; } = null;
         public IEnumerable<Mod>? CurrentlySelectedMods { get; private set; } = null;
-        public bool HasSelection => CurrentlySelectedMod is not null;
 
         public BindableModCollection Mods { get; init; }
 
@@ -56,6 +55,8 @@ namespace Imya.UI.Components
         }
         private bool _showAttributes = true;
 
+        
+
         private void SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             OnSelectionChanged();
@@ -67,7 +68,6 @@ namespace Imya.UI.Components
 
             CurrentlySelectedMods = selectedItems.Select(x => x.Model).OrderBy(x => x, Mods.Order ?? CompareByActiveCategoryName.Default);
             CurrentlySelectedMod = CurrentlySelectedMods.FirstOrDefault();
-
             ModList_SelectionChanged?.Invoke(CurrentlySelectedMod);
         }
 
@@ -107,16 +107,6 @@ namespace Imya.UI.Components
         {
             string filterText = SearchTextBox.Text;
             Mods.Filter = string.IsNullOrWhiteSpace(filterText) ? null : x => x.HasKeywords(filterText);
-        }
-
-        public bool AnyActiveSelected()
-        {
-            return CurrentlySelectedMods?.Any(x => x.IsActive) ?? false;
-        }
-
-        public bool AnyInactiveSelected()
-        {
-            return CurrentlySelectedMods?.Any(x => !x.IsActive) ?? false;
         }
 
         public event ModListSelectionChangedHandler? ModList_SelectionChanged;

--- a/ModManager/Views/ModActivationView.xaml
+++ b/ModManager/Views/ModActivationView.xaml
@@ -23,6 +23,8 @@
         </Grid.ColumnDefinitions>
         <Grid.Resources>
             <Converters:StringFormatConverter x:Key="Format" />
+            <Converters:BooleanMultiAndConverter x:Key="BoolMultiAnd" />
+            <Converters:NegateBoolConverter x:Key="NegateBool" />
         </Grid.Resources>
         <StackPanel 
                 x:Name="UpperControls" 
@@ -70,8 +72,20 @@
                         Style="{StaticResource IMYA_BUTTON}"
                         Grid.Column="1"
                         MinHeight="32"
-                        Click="OnActivate"
-                        IsEnabled="{Binding CanActivate}">
+                        Click="OnActivate">
+                    <Button.IsEnabled>
+                        <MultiBinding Converter="{StaticResource BoolMultiAnd}"
+                                      UpdateSourceTrigger="PropertyChanged">
+                            <Binding Path="ModList.AnyInactiveSelected" 
+                                     UpdateSourceTrigger="PropertyChanged" />
+                            <Binding Path="GameSetupManager.IsGameRunning"
+                                     Converter="{StaticResource NegateBool}"
+                                     UpdateSourceTrigger="PropertyChanged" />
+                            <Binding Path="ModList.OnlyRemovedSelected"
+                                     Converter="{StaticResource NegateBool}"
+                                     UpdateSourceTrigger="PropertyChanged" />
+                        </MultiBinding>
+                    </Button.IsEnabled>
                     <StackPanel Orientation="Horizontal">
                         <materialDesign:PackIcon Style="{StaticResource IMYA_ICON}"
                                                  Kind="PlusBox"
@@ -86,8 +100,20 @@
                     Style="{StaticResource IMYA_BUTTON}"
                     Grid.Column="2"
                     MinHeight="32"
-                    Click="OnDeactivate"
-                    IsEnabled="{Binding CanDeactivate}">
+                    Click="OnDeactivate">
+                    <Button.IsEnabled>
+                        <MultiBinding Converter="{StaticResource BoolMultiAnd}"
+                                      UpdateSourceTrigger="PropertyChanged">
+                            <Binding Path="ModList.AnyActiveSelected"
+                                     UpdateSourceTrigger="PropertyChanged" />
+                            <Binding Path="GameSetupManager.IsGameRunning"
+                                     Converter="{StaticResource NegateBool}"
+                                     UpdateSourceTrigger="PropertyChanged" />
+                            <Binding Path="ModList.OnlyRemovedSelected"
+                                     Converter="{StaticResource NegateBool}"
+                                     UpdateSourceTrigger="PropertyChanged" />
+                        </MultiBinding>
+                    </Button.IsEnabled>
                     <StackPanel HorizontalAlignment="Left"
                                 Orientation="Horizontal"
                                 Margin="10,0,0,0">
@@ -103,8 +129,17 @@
                     Style="{StaticResource IMYA_BUTTON}"
                     Grid.Column="3"
                     MinHeight="32"
-                    Click="OnDelete"
-                    IsEnabled="{Binding CanDelete}">
+                    Click="OnDelete">
+                    <Button.IsEnabled>
+                        <MultiBinding Converter="{StaticResource BoolMultiAnd}"
+                                      UpdateSourceTrigger="PropertyChanged">
+                            <Binding Path="ModList.HasSelection"
+                                     UpdateSourceTrigger="PropertyChanged" />
+                            <Binding Path="GameSetupManager.IsGameRunning"
+                                     Converter="{StaticResource NegateBool}"
+                                     UpdateSourceTrigger="PropertyChanged" />
+                        </MultiBinding>
+                    </Button.IsEnabled>
                     <StackPanel HorizontalAlignment="Left"
                                 Orientation="Horizontal"
                                 Margin="10,0,0,0">
@@ -135,8 +170,12 @@
                         Style="{StaticResource IMYA_BUTTON}"
                         MinHeight="32"
                         Click="LoadProfileClick"
-                        Grid.Column="1"
-                        IsEnabled="{Binding CanLoadProfile, UpdateSourceTrigger=PropertyChanged}">
+                        Grid.Column="1">
+                    <Button.IsEnabled>
+                        <Binding Path="GameSetupManager.IsGameRunning"
+                                 Converter="{StaticResource NegateBool}"
+                                 UpdateSourceTrigger="PropertyChanged"/>
+                    </Button.IsEnabled>
                     <StackPanel Orientation="Horizontal"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Stretch"

--- a/ModManager_Classes/Models/GameLauncher/GameLauncherBase.cs
+++ b/ModManager_Classes/Models/GameLauncher/GameLauncherBase.cs
@@ -1,0 +1,60 @@
+﻿using Imya.Utils;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imya.Models.GameLauncher
+{
+    public abstract class GameLauncherBase : IDisposable
+    {
+        public event IGameLauncher.GameStartEventHandler GameStarted = delegate { };
+        public event IGameLauncher.GameCloseEventHandler GameExited = delegate { };
+
+        public Process? RunningGame { get; protected set; }
+        protected GameScanner _scanner;
+
+        public GameLauncherBase() {
+            _scanner = new GameScanner();
+            RunningGame = null;
+        }
+
+        protected async Task ScanGameAsync()
+        {
+            Console.WriteLine($"Start Process exited! Starting Game Scan");
+            RunningGame = await _scanner.ScanForRunningGameAsync(30);
+
+            if (RunningGame is null)
+            {
+                OnGameExited(-1, false);
+                return;
+            }
+            RunningGame.EnableRaisingEvents = true;
+            RunningGame.Exited += OnGameExit;
+            await RunningGame.WaitForExitAsync();
+        }
+
+        protected void OnGameExit(object sender, EventArgs e)
+        {
+            var process = sender as Process;
+            Console.WriteLine($"Anno 1800 exited with Code {process?.ExitCode}");
+            int exitCode = process?.ExitCode ?? -1;
+            OnGameExited(exitCode);
+            RunningGame = null;
+        }
+
+        protected void OnGameExited(int exitCode, bool IsRegularExit = true) => GameExited.Invoke(exitCode, IsRegularExit);
+
+        protected void OnGameStarted() => GameStarted.Invoke();
+
+        public void Dispose()
+        {
+            foreach (Delegate d in GameExited.GetInvocationList())
+                GameExited -= (IGameLauncher.GameCloseEventHandler)d;
+            foreach (Delegate d in GameStarted.GetInvocationList())
+                GameStarted -= (IGameLauncher.GameStartEventHandler)d;
+        }
+    }
+}

--- a/ModManager_Classes/Models/GameLauncher/GameLauncherFactory.cs
+++ b/ModManager_Classes/Models/GameLauncher/GameLauncherFactory.cs
@@ -1,0 +1,24 @@
+﻿using Imya.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imya.Models.GameLauncher
+{
+    public class GameLauncherFactory : IGameLauncherFactory
+    {
+        GameSetupManager _gameSetup; 
+
+        public GameLauncherFactory() 
+        {
+            _gameSetup = GameSetupManager.Instance; 
+        }
+
+        public IGameLauncher GetLauncher()
+        {
+            return _gameSetup.GamePlatform == GamePlatform.Steam ? new SteamGameLauncher() : new StandardGameLauncher();
+        }
+    }
+}

--- a/ModManager_Classes/Models/GameLauncher/IGameLauncher.cs
+++ b/ModManager_Classes/Models/GameLauncher/IGameLauncher.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imya.Models.GameLauncher
+{
+    public interface IGameLauncher : IDisposable
+    {
+        Process? RunningGame { get; }
+        bool HasRunningGame { get => RunningGame is not null; }
+
+        void StartGame();
+
+        delegate void GameStartEventHandler();
+        event GameStartEventHandler GameStarted;
+
+        delegate void GameCloseEventHandler(int GameExitCode, bool IsRegularExit = true);
+        event GameCloseEventHandler GameExited;
+    }
+}

--- a/ModManager_Classes/Models/GameLauncher/IGameLauncherFactory.cs
+++ b/ModManager_Classes/Models/GameLauncher/IGameLauncherFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imya.Models.GameLauncher
+{
+    public interface IGameLauncherFactory
+    {
+        IGameLauncher GetLauncher();
+    }
+}

--- a/ModManager_Classes/Models/GameLauncher/StandardGameLauncher.cs
+++ b/ModManager_Classes/Models/GameLauncher/StandardGameLauncher.cs
@@ -1,0 +1,47 @@
+﻿using Imya.Utils;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imya.Models.GameLauncher
+{
+    /* Standard Game Launch:
+     * Start startprocess
+     * startprocess calls ubiconnect
+     * startprocess gets killed
+     * ubiconnect starts the game
+     */
+    public class StandardGameLauncher : GameLauncherBase, IGameLauncher
+    {
+        private GameSetupManager _gameSetup; 
+
+        public StandardGameLauncher()
+        {
+            _scanner = new GameScanner();
+            _gameSetup = GameSetupManager.Instance;
+
+            RunningGame = null; 
+        }
+
+        public void StartGame()
+        {
+            _ = Task.Run(async () => await LaunchUbiAsync());
+        }
+
+        private async Task LaunchUbiAsync()
+        {
+            using Process process = new Process();
+            process.StartInfo.FileName = _gameSetup.ExecutablePath;
+            process.Start();
+
+            Console.WriteLine("Anno 1800 started.");
+            OnGameStarted();
+            await process.WaitForExitAsync();
+
+            await ScanGameAsync(); 
+        }
+    }
+}

--- a/ModManager_Classes/Models/GameLauncher/SteamGameLauncher.cs
+++ b/ModManager_Classes/Models/GameLauncher/SteamGameLauncher.cs
@@ -1,0 +1,69 @@
+﻿using Imya.Utils;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Imya.Models.GameLauncher
+{
+    /* Steam Game Launch: 
+     * 
+     * start startprocess
+     * startprocess calls steam
+     * startprocess gets killed
+     * steam starts ubisoft_process
+     * ubisoft_process does shit and then also gets killed
+     * ubisoft starts game.
+     */
+    public class SteamGameLauncher : GameLauncherBase, IGameLauncher
+    {
+        private GameSetupManager _gameSetup;
+
+        public SteamGameLauncher()
+        {
+            _scanner = new GameScanner();
+            _gameSetup = GameSetupManager.Instance;
+
+            RunningGame = null;
+        }
+
+        public void StartGame()
+        {
+            _ = Task.Run(async () =>
+            {
+                await LaunchSteamAsync();
+                await ScanUbiAsync();
+                await ScanGameAsync(); 
+            });
+        }
+
+        private async Task LaunchSteamAsync()
+        {
+            var ps = new ProcessStartInfo("steam://rungameid/916440")
+            {
+                UseShellExecute = true,
+                Verb = "open"
+            };
+            var game = Process.Start(ps);
+
+            if (game is null)
+            {
+                OnGameExited(-1, false);
+                return;
+            }
+
+            Console.WriteLine("Anno 1800 started.");
+            OnGameStarted(); 
+            game.EnableRaisingEvents = true;
+            await game.WaitForExitAsync();
+        }
+
+        private async Task ScanUbiAsync()
+        {
+            var ubiprocess = await _scanner.ScanForRunningGameAsync(2);
+            await ubiprocess.WaitForExitAsync();
+        }
+    }
+}

--- a/ModManager_Classes/Utils/GameSetupManager.cs
+++ b/ModManager_Classes/Utils/GameSetupManager.cs
@@ -225,6 +225,9 @@ namespace Imya.Utils
 
         private bool IsSteamVersion()
         {
+            if (ExecutableDir is null)
+                return false;
+
             var path = Path.Combine(ExecutableDir, "steam_api64.dll");
             return File.Exists(path);
         }


### PR DESCRIPTION
Steam needs a different launcher after GU17.
- refactored the launching code 
- added standard launch
- added steam launch

Currently GameSetupManager checks for the presence of `steam_api64.dll` in Bin/Win64. If it's present, Steam launch is used, if not, Standard is used.