### PR TITLE
Display proper error messages

### DIFF
--- a/ModManager/Models/AuthenticationController.cs
+++ b/ModManager/Models/AuthenticationController.cs
@@ -1,6 +1,7 @@
 ﻿using Imya.Models;
 using Imya.Models.NotifyPropertyChanged;
 using Imya.UI.Popup;
+using Imya.UI.Utils;
 using Imya.Utils;
 using System;
 using System.Collections.Generic;
@@ -48,9 +49,6 @@ namespace Imya.UI.Models
 
         public void Logout()
         {
-            var dialogresult = new GenericOkayPopup() { MESSAGE = new SimpleText("Are you sure you want to log out?") }.ShowDialog();
-            if (dialogresult is false) return;
-
             GithubClientProvider.Client.Credentials = Octokit.Credentials.Anonymous;
             IsAuthenticated = false;
             AvatarUri = null;

--- a/ModManager/Utils/PopupCreator.cs
+++ b/ModManager/Utils/PopupCreator.cs
@@ -44,9 +44,16 @@ namespace Imya.UI.Utils
             HasCancelButton = false
         };
 
-        public static GenericOkayPopup CreateGithubExceptionPopup(InstallationException e) => new() 
+        public static GenericOkayPopup CreateExceptionPopup(Exception e) => new() 
         { 
             MESSAGE = new SimpleText(e.Message),
+            OK_TEXT = TextManager.GetText("DIALOG_OKAY"),
+            HasCancelButton = false
+        };
+
+        public static GenericOkayPopup CreateApiRateExceededPopup() => new()
+        {
+            MESSAGE = TextManager.GetText("API_RATELIMIT_REACHED"),
             OK_TEXT = TextManager.GetText("DIALOG_OKAY"),
             HasCancelButton = false
         };

--- a/ModManager/Views/Components/Dashboard.xaml.cs
+++ b/ModManager/Views/Components/Dashboard.xaml.cs
@@ -146,6 +146,9 @@ namespace Imya.UI.Components
 
         private void LogoutButtonClick(object sender, RoutedEventArgs e)
         {
+            var dialogresult = PopupCreator.CreateLogoutPopup().ShowDialog();
+            if (dialogresult is false) return;
+
             AuthenticationController.Logout();
         }
     }

--- a/ModManager/resources/texts.json
+++ b/ModManager/resources/texts.json
@@ -1820,6 +1820,19 @@
     "Spanish": null,
     "Taiwanese": null
   },
+  "API_RATELIMIT_REACHED": {
+    "Chinese": null,
+    "English": "You have exceeded your rate limit per hour (This is imposed by GitHub). To get access again, you can login.",
+    "French": null,
+    "German": "Du hast das Anfragenlimit pro Stunde erreicht (Dies ist leider so von Github vorgegeben). Um wieder Zugriff zu bekommen, kannst Du dich allerdings einloggen.",
+    "Italian": null,
+    "Japanese": null,
+    "Korean": null,
+    "Polish": null,
+    "Russian": null,
+    "Spanish": null,
+    "Taiwanese": null
+  },
   "CONTROLS_TOGGLE_HIDE": {
     "Chinese": null,
     "English": "hide",

--- a/ModManager_Classes/GithubIntegration/RepositoryInformation/IReadmeProvider.cs
+++ b/ModManager_Classes/GithubIntegration/RepositoryInformation/IReadmeProvider.cs
@@ -2,7 +2,7 @@
 
 namespace Imya.GithubIntegration.RepositoryInformation
 {
-    internal interface IReadmeProvider
+    public interface IReadmeProvider
     {
         public Task<String?> GetReadmeAsync(GithubRepoInfo repoInfo);
     }

--- a/ModManager_Classes/GithubIntegration/RepositoryInformation/RepositoryProvider.cs
+++ b/ModManager_Classes/GithubIntegration/RepositoryInformation/RepositoryProvider.cs
@@ -18,10 +18,12 @@ namespace Imya.GithubIntegration.RepositoryInformation
             {
                 return await _githubClient.Repository.Release.GetLatest(repository.Owner, repository.Name);
             }
-            catch (ApiException e)
+            catch (RateLimitExceededException e)
             {
-                
+                throw e; 
             }
+            catch (ApiException e)
+            { }
             return null;
         }
 
@@ -31,10 +33,12 @@ namespace Imya.GithubIntegration.RepositoryInformation
             {
                 return await _githubClient.Repository.Release.GetAll(repository.Owner, repository.Name);
             }
-            catch (ApiException e)
+            catch (RateLimitExceededException e)
             {
-
+                throw e;
             }
+            catch (ApiException e)
+            { }
             return null;
         }
 
@@ -44,10 +48,12 @@ namespace Imya.GithubIntegration.RepositoryInformation
             {
                 return await _githubClient.Repository.Get(repoInfo.Owner, repoInfo.Name);
             }
-            catch (ApiException e)
+            catch (RateLimitExceededException e)
             {
-                
+                throw e;
             }
+            catch (ApiException e)
+            { }
             return null;
         }
     }

--- a/ModManager_Classes/GithubIntegration/StaticData/StaticReadmeProvider.cs
+++ b/ModManager_Classes/GithubIntegration/StaticData/StaticReadmeProvider.cs
@@ -17,10 +17,15 @@ namespace Imya.GithubIntegration.StaticData
             {
                 return await cache.GetOrCreateAsync(repoInfo, _ => ReadmeFunc(repoInfo));
             }
+            catch (RateLimitExceededException e)
+            {
+                throw e;
+            }
             catch (ApiException e)
             {
-                return null;
+                return null; 
             }
+            
         }
 
         private async Task<String> ReadmeFunc(GithubRepoInfo repoInfo)


### PR DESCRIPTION
When getting API errors, the error messages were pretty cryptic or didn't appear at all. 

Behavior now: 
- When Rate Limit exceeded: in any case there is rate limit Popup. 
- When Request fails normally: only a download request will trigger a popup