### PR TITLE
Remove banner image from readme

### DIFF
--- a/ModManager/Views/Components/ModDescriptionDisplay.xaml.cs
+++ b/ModManager/Views/Components/ModDescriptionDisplay.xaml.cs
@@ -225,9 +225,13 @@ namespace Imya.UI.Components
 
             if (description.StartsWith("file::"))
             {
-                 string descAsPath = Path.Combine(Mod.FullModPath, description.Substring(6));
-                 if(File.Exists(descAsPath))
-                     MarkdownDescription = File.ReadAllText(descAsPath);
+                string descAsPath = Path.Combine(Mod.FullModPath, description.Substring(6));
+                if (File.Exists(descAsPath))
+                {
+                    MarkdownDescription = File.ReadAllText(descAsPath);
+                    // Remove banner image as we have it already
+                    MarkdownDescription = System.Text.RegularExpressions.Regex.Replace(MarkdownDescription, @"!\[[^\]]*\]\(\.\/banner\.(jpg|png)\)", "");
+                }
             }
             else if (description.StartsWith("# "))
                 MarkdownDescription = description;

--- a/ModManager/Views/Components/ModDescriptionDisplay.xaml.cs
+++ b/ModManager/Views/Components/ModDescriptionDisplay.xaml.cs
@@ -231,6 +231,10 @@ namespace Imya.UI.Components
                     MarkdownDescription = File.ReadAllText(descAsPath);
                     // Remove banner image as we have it already
                     MarkdownDescription = System.Text.RegularExpressions.Regex.Replace(MarkdownDescription, @"!\[[^\]]*\]\(\.\/banner\.(jpg|png)\)", "");
+
+                    // Remove all images
+                    // TODO we should support this eventually?
+                    MarkdownDescription = System.Text.RegularExpressions.Regex.Replace(MarkdownDescription, @"!\[[^\]]*\]\([^\)]+\)", "");
                 }
             }
             else if (description.StartsWith("# "))


### PR DESCRIPTION
And other images as well for now until we support it.

That change is the last I'd need to use `file::README.md` instead of the lengthy description within the `modinfo.json`.