### PR TITLE
Improve GitHub browser

### DIFF
--- a/ModManager/App.xaml
+++ b/ModManager/App.xaml
@@ -41,6 +41,8 @@
                 <Setter Property="Foreground"
                         Value="{DynamicResource TextColorBrush}">
                 </Setter>
+                <Setter Property="PagePadding"
+                        Value="15" />
             </Style>
 
             <Style x:Key="H1Style"
@@ -95,7 +97,7 @@
                         Value="UniformToFill">
                 </Setter>
                 <Setter Property="MaxWidth"
-                        Value="{Binding ElementName=DescriptionFlowViewer, Path=ActualWidth, UpdateSourceTrigger=PropertyChanged}"></Setter>
+                        Value="{Binding ElementName=DescriptionFlowViewer, Path=Document.MinPageWidth, UpdateSourceTrigger=PropertyChanged}" />
                 <Style.Triggers>
                     <Trigger Property="Tag"
                              Value="imageright">

--- a/ModManager/Views/GithubBrowserView.xaml
+++ b/ModManager/Views/GithubBrowserView.xaml
@@ -95,31 +95,17 @@
                 <DataTemplate>
                     <Grid Margin="8">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition />
-                            <ColumnDefinition />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="auto" />
                         </Grid.ColumnDefinitions>
-                        <StackPanel Orientation="Horizontal"
-                                    VerticalAlignment="Center">
-                            <TextBlock Text="{Binding Owner}"
-                                       Style="{StaticResource IMYA_TEXT}"
-                                       FontWeight="Bold"></TextBlock>
-                            <TextBlock Text="{Binding Name}"
-                                       Style="{StaticResource IMYA_TEXT}"
-                                       Padding="5,0"></TextBlock>
-                            
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal"
-                                    VerticalAlignment="Center"
-                                    Grid.Column="2">
-                            <Rectangle Width="2"
-                                       Fill="{DynamicResource ComponentColorBrush_Inactive}"
-                                       Margin="10,0,10,0" />
-                            <TextBlock Text="{Binding ReleaseID}"
-                                       Style="{StaticResource IMYA_TEXT}"
-                                       HorizontalAlignment="Left"
-                                       FontWeight="ExtraLight"></TextBlock>
-                        </StackPanel>
-
+                        <TextBlock Text="{Binding DisplayName}"
+                                   Style="{StaticResource IMYA_TEXT}"
+                                   FontWeight="Bold" />
+                        <TextBlock Text="{Binding DisplayCreator}"
+                                   HorizontalAlignment="Right"
+                                   Style="{StaticResource IMYA_TEXT}"
+                                   Padding="5,0"
+                                   Grid.Column="1" />
                     </Grid>
                 </DataTemplate>
             </ListBox.ItemTemplate>

--- a/ModManager/Views/GithubBrowserView.xaml.cs
+++ b/ModManager/Views/GithubBrowserView.xaml.cs
@@ -239,16 +239,23 @@ namespace Imya.UI.Views
         }
 
         #region hacky_image_size_correction
-        private async void DescriptionFlowViewer_SizeChanged(object sender, SizeChangedEventArgs e)
+        private void DescriptionFlowViewer_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            //rerender the flow document cuz images 
-            await Application.Current.Dispatcher.BeginInvoke(
-                () =>
-                {
-                    if (DescriptionFlowViewer.Document is null)
-                        return;
-                    DescriptionFlowViewer.Document.PageWidth = DescriptionFlowViewer.Document.PageWidth;
-                });
+            if (sender is FlowDocumentScrollViewer viewer)
+            {
+                double width = viewer.ActualWidth;
+                //rerender the flow document cuz images 
+                Application.Current.Dispatcher.Invoke(
+                    () =>
+                    {
+                        if (DescriptionFlowViewer.Document is null)
+                            return;
+
+                        DescriptionFlowViewer.Document.PageWidth = width;
+                        // image width is set in style, abuse MinPageWidth to inform about the 30px padding
+                        DescriptionFlowViewer.Document.MinPageWidth = width - 30;
+                    });
+            }
         }
         #endregion
 

--- a/ModManager_Classes/GithubIntegration/GithubRepoInfo.cs
+++ b/ModManager_Classes/GithubIntegration/GithubRepoInfo.cs
@@ -15,6 +15,10 @@ namespace Imya.GithubIntegration
         public String Owner { get; init; }
         public String ReleaseID { get; init; }
 
+        public string? CreatorName { get; init; }
+        public string? ModName { get; init; }
+        public string? Readme { get; init; }
+
         public GithubRepoInfo(string name, string owner, string releaseid)
         {
             Name = name;

--- a/ModManager_Classes/GithubIntegration/GithubRepoInfo.cs
+++ b/ModManager_Classes/GithubIntegration/GithubRepoInfo.cs
@@ -1,11 +1,5 @@
-﻿using Imya.GithubIntegration.StaticData;
-using Octokit;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 
 namespace Imya.GithubIntegration
 {
@@ -14,16 +8,22 @@ namespace Imya.GithubIntegration
         public String Name { get; init; }
         public String Owner { get; init; }
         public String ReleaseID { get; init; }
+        private string _releaseName;
 
         public string? CreatorName { get; init; }
         public string? ModName { get; init; }
         public string? Readme { get; init; }
+
+        public string DisplayCreator => CreatorName ?? Owner;
+        public string DisplayName => ModName ?? _releaseName;
 
         public GithubRepoInfo(string name, string owner, string releaseid)
         {
             Name = name;
             Owner = owner;
             ReleaseID = releaseid;
+
+            _releaseName = Regex.Replace(Regex.Replace(ReleaseID, @"(\.zip|v\*|\*)", ""), @"[_.-]", " ").Trim();
         }
 
         public override bool Equals([NotNullWhen(true)] object? obj)

--- a/ModManager_Classes/GithubIntegration/JsonData/JsonRepoInfoSource.cs
+++ b/ModManager_Classes/GithubIntegration/JsonData/JsonRepoInfoSource.cs
@@ -15,10 +15,13 @@ namespace Imya.GithubIntegration.JsonData
         {
             public struct RepoIndexEntry
             {
-                public string? name;
+                //public string? name; // unused and not defined
                 public string? repo;
                 public string? owner;
                 public string? id;
+                public string? creatorName;
+                public string? modName;
+                public string? readme;
 
                 // optional
                 public string? download;
@@ -63,7 +66,12 @@ namespace Imya.GithubIntegration.JsonData
 
             // TODO static is hardcoded now, but shouldn't as soon as we support the others
             var packages = index.packages.Where(x => x.repo is not null && x.owner is not null && x.download is not null);
-            repositories = packages.Select(x => new GithubRepoInfo(x.repo!, x.owner!, x.download!));
+            repositories = packages.Select(x => new GithubRepoInfo(x.repo!, x.owner!, x.download!)
+            {
+                CreatorName = x.creatorName,
+                ModName = x.modName,
+                Readme = x.readme,
+            });
             return true;
         }
 

--- a/ModManager_Classes/GithubIntegration/StaticData/StaticFilenameReadmeStrategy.cs
+++ b/ModManager_Classes/GithubIntegration/StaticData/StaticFilenameReadmeStrategy.cs
@@ -39,7 +39,7 @@ namespace Imya.GithubIntegration.StaticData
 
         private async Task<String> ReadmeFunc(GithubRepoInfo repoInfo)
         {
-            var readme = await _client.Repository.Content.GetAllContents(repoInfo.Owner, repoInfo.Name, _desiredFilename);
+            var readme = await _client.Repository.Content.GetAllContents(repoInfo.Owner, repoInfo.Name, repoInfo.Readme ?? _desiredFilename);
             var content = readme.FirstOrDefault();
             if (content is null) return String.Empty;
             return content!.Content;


### PR DESCRIPTION
Improve GitHub browser:
- Show mod name and author (beautified from download, or defined in `packages.json` `modName` and `creatorName`).
  Repo name and zip name were in most cases almost identical.
- Support relative image urls like `![](./banner.jpg)`
- Fix readme image width
- Make GitHub readme path configurable with `readme` in `packages.json` (useful for multiple mods from one repo)

![image](https://github.com/anno-mods/iModYourAnno/assets/12190313/16b49fcf-7235-486e-8e23-db87d3f33da1)
